### PR TITLE
Make NPC tag/status draggable to actor sheet

### DIFF
--- a/module/mist-engine-fvtt.mjs
+++ b/module/mist-engine-fvtt.mjs
@@ -143,10 +143,17 @@ Handlebars.registerHelper("textWithTags", function (str) {
   const tags = extractBrackets(str);
   let result = str;
   tags.forEach((tag) => {
+    const [name, value] = tag.split("-");
     if (tag.includes("-")) {
-      result = result.replace(`[${tag}]`, `<span class="status">${tag}</span>`);
+      result = result.replace(
+        `[${tag}]`,
+        `<span class="status" data-drag="true" data-type="status" data-name="${name}" data-value="${value}">${tag}</span>`
+      );
     } else {
-      result = result.replace(`[${tag}]`, `<span class="tag">${tag}</span>`);
+      result = result.replace(
+        `[${tag}]`,
+        `<span class="tag" data-drag="true" data-type="tag" data-name="${name}">${tag}</span>`
+      );
     }
   });
   return result;

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -357,7 +357,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
         if ('link' in event.target.dataset) return;
 
         // Extract the data you need
-        let dragData = null;
+        let dragData = el.dataset;
 
         if (!dragData) return;
 
@@ -382,12 +382,20 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
     async _onDrop(event) {
         const data = TextEditor.getDragEventData(event);
 
-        //console.log(data.type);
         // Handle different data types
         switch (data.type) {
-            // write your cases
+            case 'tag':
+            case 'status':
+                const floatingTagsAndStatuses = this.actor.system.floatingTagsAndStatuses;
+                floatingTagsAndStatuses.push({ name: data.name, value: data.value, description: '' });
+                this.actor.update({
+                    'system.floatingTagsAndStatuses': floatingTagsAndStatuses
+                });
+                break;
+            default:
+                console.warn('Unknown drop type', data);
+                break;
         }
 
         return super._onDrop?.(event);
-    }
-}
+    }}


### PR DESCRIPTION
Implemented tag/status drag & drop from an NPC sheet to an Actor sheet. Any tag or status wrapped using the `textWithTags` helper becomes draggable, with its dataset used to populate the drag/drop data.