### PR TITLE
Add "tidyTags" configuration value

### DIFF
--- a/module/lib/configuration.mjs
+++ b/module/lib/configuration.mjs
@@ -27,4 +27,13 @@ export function setupConfiguration() {
         type: Boolean,
         default: false
     });
+
+    game.settings.register("mist-engine-fvtt", "tidyTagsOnCharacterSheet", {
+        name: "Tidy Tags on Character Sheet",
+        hint: "Hide planned tags and eliminate blank lines in a character's themes",
+        scope: "user",
+        config: true,
+        type: Boolean,
+        default: false
+    });    
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -124,6 +124,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
         // Adding a pointer to CONFIG.MISTENGINE
         context.config = CONFIG.MISTENGINE;
 
+        context.tidyTags = game.settings.get("mist-engine-fvtt", "tidyTagsOnCharacterSheet");
         context.biographyHTML = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
             this.document.system.biography,
             {

--- a/templates/actor/parts/character-themebooks.hbs
+++ b/templates/actor/parts/character-themebooks.hbs
@@ -1,4 +1,5 @@
 <div class="themebooks-container {{#unless system.editMode}}themebooks-container-stylized{{/unless}} grid grid-4col grid-themebook-container {{#if system.editMode}}edit-mode{{/if}}">
+
     {{!-- If there are no themebooks, show a message --}}
     {{#if themebooksEmpty}}
     <div class="themebook-container">
@@ -11,6 +12,6 @@
     {{!-- Iterate over each themebook and render the partial --}}
     {{#each themebooks as |book index|}}
     {{> 'systems/mist-engine-fvtt/templates/actor/parts/themebook-partial.hbs' themebook=book id=book._id
-    editMode=../system.editMode}}
+    editMode=../system.editMode tidyTags=../tidyTags}}
     {{/each}}
 </div>

--- a/templates/actor/parts/tab-litm-character.hbs
+++ b/templates/actor/parts/tab-litm-character.hbs
@@ -3,7 +3,7 @@
     <div class="character-sheet-divider flexrow">
         <div class="right-side {{#if system.editMode}}edit-mode{{/if}}">
             <div class="litm-character-themebooks-container">
-                {{> 'systems/mist-engine-fvtt/templates/actor/parts/character-themebooks.hbs' themebooks=themebooks}}
+                {{> 'systems/mist-engine-fvtt/templates/actor/parts/character-themebooks.hbs' themebooks=themebooks tidyTags=tidyTags}}
                 <div class="themebooks-container grid grid-4col grid-themebook-container {{#if system.editMode}}edit-mode{{/if}}">
                     {{> 'systems/mist-engine-fvtt/templates/actor/parts/character-quintessences-partial.hbs'
                     editMode=system.editMode}}

--- a/templates/actor/parts/themebook-partial.hbs
+++ b/templates/actor/parts/themebook-partial.hbs
@@ -28,23 +28,23 @@
             {{> "systems/mist-engine-fvtt/templates/shared/litm/themebook-powertag-line.hbs" index=1 id=themebook._id
             powertag=themebook.system.powertag1 editMode=editMode firstTag=true}}
             {{> "systems/mist-engine-fvtt/templates/shared/litm/themebook-powertag-line.hbs" index=2 id=themebook._id
-            powertag=themebook.system.powertag2 editMode=editMode}}
+            powertag=themebook.system.powertag2 editMode=editMode tidyTags=tidyTags}}
             {{> "systems/mist-engine-fvtt/templates/shared/litm/themebook-powertag-line.hbs" index=3 id=themebook._id
-            powertag=themebook.system.powertag3 editMode=editMode}}
+            powertag=themebook.system.powertag3 editMode=editMode tidyTags=tidyTags}}
             {{> "systems/mist-engine-fvtt/templates/shared/litm/themebook-powertag-line.hbs" index=4 id=themebook._id
-            powertag=themebook.system.powertag4 editMode=editMode}}
+            powertag=themebook.system.powertag4 editMode=editMode tidyTags=tidyTags}}
             {{> "systems/mist-engine-fvtt/templates/shared/litm/themebook-powertag-line.hbs" index=5 id=themebook._id
-            powertag=themebook.system.powertag5 editMode=editMode}}
+            powertag=themebook.system.powertag5 editMode=editMode tidyTags=tidyTags}}
             {{> "systems/mist-engine-fvtt/templates/shared/litm/themebook-powertag-line.hbs" index=6 id=themebook._id
-            powertag=themebook.system.powertag6 editMode=editMode}}
+            powertag=themebook.system.powertag6 editMode=editMode tidyTags=tidyTags}}
             {{> "systems/mist-engine-fvtt/templates/shared/litm/themebook-powertag-line.hbs" index=7 id=themebook._id
-            powertag=themebook.system.powertag7 editMode=editMode}}
+            powertag=themebook.system.powertag7 editMode=editMode tidyTags=tidyTags}}
             {{> "systems/mist-engine-fvtt/templates/shared/litm/themebook-powertag-line.hbs" index=8 id=themebook._id
-            powertag=themebook.system.powertag8 editMode=editMode}}
+            powertag=themebook.system.powertag8 editMode=editMode tidyTags=tidyTags}}
             {{> "systems/mist-engine-fvtt/templates/shared/litm/themebook-powertag-line.hbs" index=9 id=themebook._id
-            powertag=themebook.system.powertag9 editMode=editMode}}
+            powertag=themebook.system.powertag9 editMode=editMode tidyTags=tidyTags}}
             {{> "systems/mist-engine-fvtt/templates/shared/litm/themebook-powertag-line.hbs" index=10 id=themebook._id
-            powertag=themebook.system.powertag10 editMode=editMode}}
+            powertag=themebook.system.powertag10 editMode=editMode tidyTags=tidyTags}}
 
             {{> "systems/mist-engine-fvtt/templates/shared/litm/themebook-weakness-line.hbs" index=1 id=themebook._id
             weaknesstag=themebook.system.weaknesstag1 editMode=editMode}}

--- a/templates/shared/litm/themebook-powertag-line.hbs
+++ b/templates/shared/litm/themebook-powertag-line.hbs
@@ -1,23 +1,29 @@
-<div class="item-powertag-line flexrow">
     {{#if editMode}}
+    <div class="item-powertag-line flexrow">
         <strong style="flex-grow:0.3;" class="letter-box">{{questionIndexToLetter index}}</strong>
         <input type="checkbox" class="themebook-entry-input" data-item-id="{{id}}" data-key="system.powertag{{index}}.planned" data-source="{{source}}"
         {{#if powertag.planned}}checked{{/if}} title="{{localize "MIST_ENGINE.HELP.Titles.PlannedPowertag"}}" style="flex-grow:0.3; margin-right: 0.5em;"/>
         <input class="themebook-entry-input" data-item-id="{{id}}" type="text" data-key="system.powertag{{index}}.name" data-source="{{source}}"
         value="{{powertag.name}}" placeholder="{{powerTagQuestionPlaceholder index powertag.question}}" title="{{powerTagQuestionPlaceholder index powertag.question}}" title="{{localize "MIST_ENGINE.TITLES.Powertag"}}" style="flex-grow: 8;"/>
+    </div>
     {{else}}
         {{#if (tagFilledAndNotPlanned powertag)}}
-        {{#if noBurn}}
+        <div class="item-powertag-line flexrow">
+            {{#if noBurn}}
+            {{else}}
+                <span class="burn-indicator" data-action="toggleToBurn" data-item-id="{{id}}" data-powertag-index="{{index}}" data-source="{{source}}">
+                    <i class="burn-icon {{#if powertag.toBurn}}to-burn{{/if}}"></i>
+                </span>
+            {{/if}}
+            <span class="litm-pc-powertag powertag-name pt-selectable {{#if firstTag}}first{{/if}} {{#if powertag.selected}}selected{{/if}} {{#if powertag.burned}}burned{{/if}}" title="{{localize "MIST_ENGINE.HELP.Titles.RightClickToToggleBurnState"}}"
+                data-powertag-index="{{index}}" data-item-id="{{id}}" data-source="{{source}}">{{powertag.name}}</span>
+        </div>
         {{else}}
-        <span class="burn-indicator" data-action="toggleToBurn" data-item-id="{{id}}" data-powertag-index="{{index}}" data-source="{{source}}">
-            <i class="burn-icon {{#if powertag.toBurn}}to-burn{{/if}}"></i>
-        </span>
-        {{/if}}
-        <span class="litm-pc-powertag powertag-name pt-selectable {{#if firstTag}}first{{/if}} {{#if powertag.selected}}selected{{/if}} {{#if powertag.burned}}burned{{/if}}" title="{{localize "MIST_ENGINE.HELP.Titles.RightClickToToggleBurnState"}}"
-            data-powertag-index="{{index}}" data-item-id="{{id}}" data-source="{{source}}">{{powertag.name}}</span>
-        {{else}}
-            <span class="burn-indicator"></span>
-            <span class="litm-pc-powertag empty">{{powertag.name}}</span>
+            {{#unless tidyTags}}
+                <div class="item-powertag-line flexrow">
+                    <span class="burn-indicator"></span>
+                    <span class="litm-pc-powertag empty">{{powertag.name}}</span>
+                </div>
+            {{/unless}}
         {{/if}}
     {{/if}}
-</div>


### PR DESCRIPTION
This PR adds the user-level configuration setting "Tidy Tags on Character Sheet" with a default value of _false_.

If this value is set to _false_, the system behaves as normal.

If this value is set to _true_, the character sheet will omit blank lines as well as planned (but not current) tags for each theme. Scratched tags still show as normal.

Setting this value to _true_ allows a user to remove what they may see as "noise" -- that is, theme tags and blank lines that are not currently applicable to the character and therefore do not affect play -- from the character sheet while still allowing them to retain planned tags for future improvement.

Configuration screen:
<img width="1920" height="1032" alt="Configuration Screen" src="https://github.com/user-attachments/assets/22f6d7a7-ea88-45f0-94c4-b97a1eb08de1" />

Setting with value false:
<img width="1920" height="1032" alt="without-tidytags" src="https://github.com/user-attachments/assets/1383caa9-68fe-4d5c-8f51-821cd2c92f6a" />

Setting with value true:
<img width="1920" height="1032" alt="with-tidytags" src="https://github.com/user-attachments/assets/26491cfc-cc05-44b1-ae3e-fe3596d9f0f2" />

Feel free to make any improvements to the configuration screen text (header or description) that you see fit.