### PR TITLE
fix: fixed-width theme cards that wrap instead of stretching (#37)

### DIFF
--- a/css/mist-engine-fvtt.css
+++ b/css/mist-engine-fvtt.css
@@ -2422,11 +2422,11 @@ article.cc-enriched section.journal-entry-content {
   margin-top: 0px;
   margin-bottom: 5px;
   min-width: 233px;
-  grid-template-columns: repeat(4, 186px);
-  justify-content: space-between;
+  grid-template-columns: repeat(auto-fit, 186px);
+  justify-content: center;
 }
 .mist-engine .themebooks-container.edit-mode {
-  grid-template-columns: repeat(4, 260px);
+  grid-template-columns: repeat(auto-fit, 260px);
 }
 .mist-engine .themebooks-container-stylized > :nth-child(2) {
   top: 3.75rem;

--- a/src/scss/components/_themebook.scss
+++ b/src/scss/components/_themebook.scss
@@ -2,10 +2,10 @@
     margin-top: 0px;
     margin-bottom: 5px;
     min-width: 233px;
-    grid-template-columns: repeat(4, 186px);
-    justify-content: space-between;
+    grid-template-columns: repeat(auto-fit, 186px);
+    justify-content: center;
     &.edit-mode{
-        grid-template-columns: repeat(4, 260px);
+        grid-template-columns: repeat(auto-fit, 260px);
     }
 }
 


### PR DESCRIPTION
Fixes #37 

.themebooks-container already forced fixed-pixel columns
(repeat(4, 186px)/260px) via a higher-specificity rule that silently
overrode .grid-4col's fractional definition, so cards weren't actually
stretching — they overflowed on narrow windows (fixed count, no wrap)
and drifted apart on wide ones (justify-content: space-between). Switch
to repeat(auto-fit, ...) so cards keep their fixed width and wrap onto
new rows instead of overflowing, and justify-content: center so the
fixed-size row centers instead of spreading (auto-fit, not auto-fill,
so unused tracks collapse and centering isn't a no-op).
