### PR TITLE
fix: backpack tags cannot be queued to burn (#98)

### DIFF
--- a/module/lib/burn-helper.mjs
+++ b/module/lib/burn-helper.mjs
@@ -1,6 +1,9 @@
 export async function clearOtherBurns(actor, keepDoc, keepKey, keepIndex) {
     if (!actor) return;
     const updates = [];
+    // Belt-and-braces: coerce to number so a caller passing a raw dataset
+    // string (e.g. "2") still matches the numeric array index below (#98).
+    const keepIndexNum = Number.parseInt(keepIndex, 10);
 
     const clear = (doc, key) => {
         if (!doc) return;
@@ -8,7 +11,7 @@ export async function clearOtherBurns(actor, keepDoc, keepKey, keepIndex) {
         if (!Array.isArray(arr) || !arr.length) return;
         let changed = false;
         const next = arr.map((tag, i) => {
-            const keep = doc === keepDoc && key === keepKey && i === keepIndex;
+            const keep = doc === keepDoc && key === keepKey && i === keepIndexNum;
             if (tag.toBurn && !keep) {
                 changed = true;
                 return { ...tag, toBurn: false };

--- a/module/lib/story-tag-adapter.mjs
+++ b/module/lib/story-tag-adapter.mjs
@@ -24,7 +24,11 @@ export class StoryTagAdapter {
         if(!data || index < 0 || index >= data.length) return false;
         if(data[index].burned) return false; // cannot select burned tags
         if(data[index].expired) return false; // expired story tags grant no Power (p. 179)
-        return ArrayFieldAdapter.toggle(item, key, index, "selected");
+        const willSelect = !data[index].selected;
+        // Deselecting also un-queues the burn, same as power tags — a tag
+        // cannot burn on a roll it no longer contributes to.
+        const patch = willSelect ? { selected: true } : { selected: false, toBurn: false };
+        return ArrayFieldAdapter.patch(item, key, index, patch);
     }
 
     static async toggleBurnSelection(actor, itemId, key, index){
@@ -34,7 +38,9 @@ export class StoryTagAdapter {
         if(!data || index < 0 || index >= data.length) return false;
         if(data[index].burned) return false; // cannot toggle burned tags
         const willBurn = !data[index].toBurn;
-        const ok = await ArrayFieldAdapter.toggle(item, key, index, "toBurn");
+        // Queueing a burn also selects the tag (and un-queueing deselects),
+        // mirroring power tags — the roll only counts selected tags.
+        const ok = await ArrayFieldAdapter.patch(item, key, index, { toBurn: willBurn, selected: willBurn });
         // Only one tag may be queued to burn (#92) — clear it on all other tags.
         if(ok && willBurn) await clearOtherBurns(actor, item, key, index);
         return ok;

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -231,7 +231,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
     async handleStoryTagBurnState(event) {
         event.preventDefault();
         const target = event.currentTarget;
-        const index = target.dataset.index;
+        const index = Number.parseInt(target.dataset.index, 10);
         const itemId = target.dataset.itemId;
         const key = target.dataset.key;
         await StoryTagAdapter.toggleBurnedState(this.actor, itemId, key, index);
@@ -241,7 +241,9 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
 
     static async #handleToggleStoryTagBurn(event, target) {
         event.preventDefault();
-        const index = target.dataset.index;
+        // Must be a number: clearOtherBurns (burn-helper.mjs) keeps the just-toggled
+        // tag via a strict `i === keepIndex` check against a numeric array index (#98).
+        const index = Number.parseInt(target.dataset.index, 10);
         const itemId = target.dataset.itemId;
         const key = target.dataset.key;
         await StoryTagAdapter.toggleBurnSelection(this.actor, itemId, key, index);
@@ -251,7 +253,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
 
     static async #handleToggleStoryTagSelection(event, target) {
         event.preventDefault();
-        const index = target.dataset.index;
+        const index = Number.parseInt(target.dataset.index, 10);
         const itemId = target.dataset.itemId;
         const key = target.dataset.key;
 
@@ -263,7 +265,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
 
     async handleStoryTagItemChanged(event) {
         event.preventDefault();
-        const index = event.currentTarget.dataset.index;
+        const index = Number.parseInt(event.currentTarget.dataset.index, 10);
         const key = event.currentTarget.dataset.key;
         const subKey = event.currentTarget.dataset.subKey;
         const itemId = event.currentTarget.dataset.itemId;
@@ -577,7 +579,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
     static async #handleDeleteStoryTag(event, target) {
         event.preventDefault();
         const itemId = target.dataset.itemId;
-        const index = target.dataset.index;
+        const index = Number.parseInt(target.dataset.index, 10);
         const key = target.dataset.key;
 
         this._saveScrollPositions();


### PR DESCRIPTION
Fixes #98 

Story-tag burn handlers read dataset.index as a string and passed it
into clearOtherBurns, whose keep-check is a strict `i === keepIndex`
against a numeric array index, so it never matched and immediately
cleared the tag just queued to burn. Parse the index to a number in
the affected actor-sheet.mjs handlers (and add a defensive Number()
coercion in clearOtherBurns itself).
