### PR TITLE
fix: selecting challenge tags no longer clears hero selection in roll dialog (#83)

### DIFF
--- a/module/apps/dice-roll-app.mjs
+++ b/module/apps/dice-roll-app.mjs
@@ -91,7 +91,7 @@ export class DiceRollApp extends HandlebarsApplicationMixin(ApplicationV2) {
     };
 
     setOptions(options) {
-        if (options.actor) {
+        if (options.actor && (options.actor.type === "character" || options.actor.type === "litm-character")) {
             // a per-roll tag/Challenge inversion is scoped to the actor it was
             // granted for; switching actors on this (singleton) dialog must not carry it over
             if (this.actor?.id !== options.actor.id) {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -261,7 +261,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
         const itemId = target.dataset.itemId;
         const key = target.dataset.key;
         await StoryTagAdapter.toggleBurnedState(this.actor, itemId, key, index);
-        DiceRollApp.getInstance({ actor: this.actor }).updateTagsAndStatuses(true);
+        DiceRollApp.instance?.updateTagsAndStatuses(true);
         MistSceneApp.getInstance().sendUpdateHookEvent(false);
     }
 
@@ -273,7 +273,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
         const itemId = target.dataset.itemId;
         const key = target.dataset.key;
         await StoryTagAdapter.toggleBurnSelection(this.actor, itemId, key, index);
-        DiceRollApp.getInstance({ actor: this.actor }).updateTagsAndStatuses(true);
+        DiceRollApp.instance?.updateTagsAndStatuses(true);
         MistSceneApp.getInstance().sendUpdateHookEvent(false);
     }
 
@@ -285,7 +285,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
 
         this._saveScrollPositions();
         await StoryTagAdapter.toggleStoryTagSelection(this.actor, itemId, key, index);
-        DiceRollApp.getInstance({ actor: this.actor }).updateTagsAndStatuses(true);
+        DiceRollApp.instance?.updateTagsAndStatuses(true);
         MistSceneApp.getInstance().sendUpdateHookEvent(false);
     }
 
@@ -304,7 +304,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
         } else {
             await StoryTagAdapter.updateStoryTag(this.actor, itemId, key, index, event.currentTarget.value,null);
         }
-        DiceRollApp.getInstance({ actor: this.actor }).updateTagsAndStatuses(true);
+        DiceRollApp.instance?.updateTagsAndStatuses(true);
         MistSceneApp.getInstance().sendUpdateHookEvent(false);
     }
 
@@ -313,7 +313,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
         const index = target.dataset.index;
         this._saveScrollPositions();
         await FloatingTagAndStatusAdapter.handleTagStatusSelectedToggle(this.actor, index);
-        DiceRollApp.getInstance({ actor: this.actor }).updateTagsAndStatuses(true);
+        DiceRollApp.instance?.updateTagsAndStatuses(true);
         this.sendFloatableTagOrStatusUpdate();
     }
 
@@ -322,7 +322,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
         const index = target.dataset.index;
         this._saveScrollPositions();
         await FloatingTagAndStatusAdapter.handleTagStatusModifierToggle(this.actor, index);
-        DiceRollApp.getInstance({ actor: this.actor }).updateTagsAndStatuses(true);
+        DiceRollApp.instance?.updateTagsAndStatuses(true);
         this.sendFloatableTagOrStatusUpdate();
     }
 
@@ -331,7 +331,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
         const index = target.dataset.index;
         this._saveScrollPositions();
         await FloatingTagAndStatusAdapter.handleTagStatusToggle(this.actor, index);
-        DiceRollApp.getInstance({ actor: this.actor }).updateTagsAndStatuses(true);
+        DiceRollApp.instance?.updateTagsAndStatuses(true);
         this.sendFloatableTagOrStatusUpdate();
     }
 
@@ -378,7 +378,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
 
         await FloatingTagAndStatusAdapter.handleFtStatChanged(this.actor, index, key, value);
         this.sendFloatableTagOrStatusUpdate();
-        DiceRollApp.getInstance({ actor: this.actor }).updateTagsAndStatuses(true);
+        DiceRollApp.instance?.updateTagsAndStatuses(true);
     }
 
     static async #handleToggleFloatingTagOrStatusMarking(event, target) {
@@ -388,7 +388,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
         await FloatingTagAndStatusAdapter.handleToggleFloatingTagOrStatusMarking(this.actor, index, target.dataset.markingIndex);
 
         this.sendFloatableTagOrStatusUpdate();
-        DiceRollApp.getInstance({ actor: this.actor }).updateTagsAndStatuses(true);
+        DiceRollApp.instance?.updateTagsAndStatuses(true);
     }
 
     async handleItemStatChanged(event) {


### PR DESCRIPTION
Fixes #83
DiceRollApp is a per-client singleton, and getInstance({actor}) always
overwrote the dialog's actor with whatever sheet last called it. Toggling
a floating tag/status or story tag on an NPC/challenge sheet reused the
shared actor-sheet.mjs handlers, which swapped the open roll dialog's
actor to the NPC, silently wiping the hero's selected tags and, worse,
making a subsequent Roll act as the NPC instead of the hero.

Refresh-only handlers in actor-sheet.mjs now use the existing
DiceRollApp.instance?.updateTagsAndStatuses(true) pattern (already used
in hooks.mjs/scene-app.mjs) instead of getInstance({actor}), so they
update an already-open dialog without ever creating one or re-targeting
its actor. DiceRollApp.setOptions also now ignores an actor option whose
type isn't character/litm-character as a belt-and-braces guard.
