### PR TITLE
feat: hotkey to open ThemeKit selection (#70)

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -118,6 +118,9 @@
         "THEMEBOOKS": {
             "Rotes": "Rotes"
         },
+        "NOTIFICATIONS": {
+            "NoCharacterAssignedForThemekitSelection": "Kein Charakter zugewiesen. Weise deinem Benutzer einen Charakter zu, um die Theme-Kit-Auswahl zu öffnen."
+        },
         "SCENE_APP": {
             "NoActiveScene": "Der Szenen-Tracker benötigt eine aktive Szene. Aktiviere zuerst eine Szene."
         },

--- a/lang/en.json
+++ b/lang/en.json
@@ -44,7 +44,8 @@
       "AddedSpecialImprovement": "Added special improvement {siName}",
       "SetQuest": "Set quest to {quest}",
       "AssignedThemekit": "Assigned themekit {themekitName} to character {characterName}",
-      "NoFellowshipThemecardFound": "No Fellowship Themecard actors found. Use \"Create New\" to make one first."
+      "NoFellowshipThemecardFound": "No Fellowship Themecard actors found. Use \"Create New\" to make one first.",
+      "NoCharacterAssignedForThemekitSelection": "No character assigned to your user. Assign a character to open the Themekit selection."
     },
     "HELP": {
       "BackpackSheet": "Backpack entries are edited directly on the character sheet (edit mode of the Backpack card). Use the Description tab for tooltip text.",

--- a/module/lib/key-binding.mjs
+++ b/module/lib/key-binding.mjs
@@ -1,5 +1,6 @@
 import { MistSceneApp } from "../apps/scene-app.mjs";
 import { HowToPlayApp } from "../apps/how-to-play-app.mjs";
+import { ThemekitSelectionApp } from "../apps/themekit-selection-app.mjs";
 
 function getActiveTextControl() {
   const el = document.activeElement;
@@ -79,6 +80,37 @@ function setupKBHowToPlayApp(){
   });
 }
 
+function setupKBThemekitSelectionApp(){
+    game.keybindings.register("mist-engine-fvtt", "showThemekitSelectionApp", {
+    name: "Show Themekit Selection App",
+    hint: "opens the theme kit selection window for your assigned character",
+    editable: [
+      {
+        // Not Ctrl/Cmd+T: browsers reserve that combo to open a new tab and
+        // never deliver it to the page, so it would silently fail to fire.
+        // Alt+T isn't claimed by browsers or Foundry core, and is still
+        // rebindable in Configure Controls.
+        key: "KeyT",
+        modifiers: ["Alt"]
+      }
+    ],
+    onDown: () => {
+        const actor = game.user.character;
+        if (!actor || actor.type !== "litm-character") {
+          ui.notifications.warn(game.i18n.localize("MIST_ENGINE.NOTIFICATIONS.NoCharacterAssignedForThemekitSelection"));
+          return true;
+        }
+        const app = new ThemekitSelectionApp();
+        app.setActor(actor);
+        app.render(true);
+      return true;
+    },
+    onUp: () => {},
+    restricted: false, // true = nur SL darf Shortcut nutzen
+    precedence: CONST.KEYBINDING_PRECEDENCE.NORMAL
+  });
+}
+
 function setupKBTaggingBindings(){
     game.keybindings.register("mist-engine-fvtt", "enrichTextWithTags", {
     name: "Make Tags",
@@ -93,5 +125,6 @@ function setupKBTaggingBindings(){
 export function setupMistEngineKeyBindings(){
     setupKBSzeneTagsApp();
     setupKBHowToPlayApp();
+    setupKBThemekitSelectionApp();
     //setupKBTaggingBindings(); not working yet
 }


### PR DESCRIPTION
Fixes #70


Adds an Alt+T keybinding that opens the ThemeKit selection app for
the user's assigned litm-character actor (mirrors the global
menuOpenThemekitSelection flow: no themebook pre-selected). Warns via
a new localized notification (en/de) when no character is assigned.
