### PR TITLE
feat: group tags before statuses in Tags & Statuses lists (#28)

### DIFF
--- a/module/apps/scene-app.mjs
+++ b/module/apps/scene-app.mjs
@@ -366,6 +366,10 @@ export class MistSceneApp extends HandlebarsApplicationMixin(ApplicationV2) {
         context.isGM = game.user.isGM;
         context.isNotGM = !game.user.isGM;
         context.hasDiceRollModifiers = this.currentSceneDataItem.system.diceRollTagsStatus.length > 0;
+        // Display-only sort (issue #28): tags before statuses, persisted array/index untouched.
+        context.sortedFloatingTagsAndStatuses = FloatingTagAndStatusAdapter.sortedFloatingView(
+            this.currentSceneDataItem.system.floatingTagsAndStatuses
+        );
 
         if (game.user.isGM) {
             foundry.utils.mergeObject(context, await this._prepareContextForCharacters());
@@ -447,7 +451,8 @@ export class MistSceneApp extends HandlebarsApplicationMixin(ApplicationV2) {
         const characterActors = [...new Set(tokens.map(t => t.actor).filter(a => a && a.type === "litm-character"))];
         characterActors.forEach(actor => {
             let selectedTags = DiceRollApp.getPreparedTagsAndStatusesForRoll(actor);
-            let floatingTagAndStatuses = actor.system.floatingTagsAndStatuses || [];
+            // Display-only sort (issue #28): tags before statuses, persisted array/index untouched.
+            let floatingTagAndStatuses = FloatingTagAndStatusAdapter.sortedFloatingView(actor.system.floatingTagsAndStatuses);
             // All weakness tags are exposed to the GM only (issue #85).
             let weaknessTags = game.user.isGM ? this.getCharacterWeaknessTags(actor) : [];
             if (!context.characters) context.characters = [];
@@ -475,7 +480,8 @@ export class MistSceneApp extends HandlebarsApplicationMixin(ApplicationV2) {
             if (!actor || actor.type !== "litm-npc") return;
             if (seenNpcActors.has(actor)) return; // linked duplicate → already added
             seenNpcActors.add(actor);
-            let floatingTagAndStatuses = actor.system.floatingTagsAndStatuses || [];
+            // Display-only sort (issue #28): tags before statuses, persisted array/index untouched.
+            let floatingTagAndStatuses = FloatingTagAndStatusAdapter.sortedFloatingView(actor.system.floatingTagsAndStatuses);
             let mightyAspects = this.getChallengeMightyAspects(actor);
             if (!context.challenges) context.challenges = [];
             context.challenges.push({

--- a/module/lib/floating-tag-and-status-adapter.mjs
+++ b/module/lib/floating-tag-and-status-adapter.mjs
@@ -98,4 +98,37 @@ export class FloatingTagAndStatusAdapter {
     static async handleToggleFloatingTagOrStatusMarking(objectToUpdate, arrayIndex, markingIndex){
         return ArrayFieldAdapter.toggle(objectToUpdate, this.PATH, arrayIndex, `markings.${markingIndex}`);
     }
+
+    /**
+     * Is this floating tag/status entry a status? Mirrors the fixup test in
+     * DiceRollApp.getPreparedTagsAndStatusesForRoll (dice-roll-app.mjs): the
+     * `isStatus` flag, OR (for entries where it wasn't set) a positive value.
+     * @param {object} entry
+     * @returns {boolean}
+     */
+    static isStatusEntry(entry){
+        return entry?.isStatus === true || (entry?.value ?? 0) > 0;
+    }
+
+    /**
+     * Build a display-only, sorted VIEW of a floating tags/statuses array:
+     * tags first, then statuses, stable within each group (insertion order
+     * preserved - see issue #28). Never mutates `list` or reorders the
+     * persisted array; every entry in the returned copy carries its
+     * ORIGINAL index from `list` as `originalIndex`, so templates can keep
+     * using that for `data-index` on elements whose handlers mutate the
+     * persisted array by index.
+     *
+     * Every context-prep site that feeds the floating-tags-and-status
+     * partial (or the scene app's own markup for it) must build the view
+     * through this single helper so the sort logic only exists once.
+     * @param {Array} list  current floatingTagsAndStatuses array (or null/undefined)
+     * @returns {Array} new array of `{...entry, originalIndex}`, sorted
+     */
+    static sortedFloatingView(list){
+        const arr = list ?? [];
+        return arr
+            .map((entry, originalIndex) => ({ ...entry, originalIndex }))
+            .sort((a, b) => Number(this.isStatusEntry(a)) - Number(this.isStatusEntry(b)));
+    }
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -129,6 +129,10 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
         const actorData = this.document.toPlainObject();
 
         context.system = actorData.system;
+        // Display-only sort (issue #28): tags before statuses, persisted array/index untouched.
+        context.system.floatingTagsAndStatuses = FloatingTagAndStatusAdapter.sortedFloatingView(
+            actorData.system.floatingTagsAndStatuses
+        );
         context.flags = actorData.flags;
         context.actor = this.document;
         context.editMode = actorData.system.editMode;

--- a/templates/scene-app/_single_challenge.hbs
+++ b/templates/scene-app/_single_challenge.hbs
@@ -2,22 +2,27 @@
     <div class="npc-subtitle-container-c">
         <div class="npc-subtitle-text pointer" data-action="clickOpenCharacterSheet" data-id="{{challenge.id}}" data-token-id="{{challenge.tokenId}}"><img src="{{challenge.img}}" class="actor-img">{{challenge.name}}{{#if challenge.isOvercome}} <span class="overcome-badge" title="{{localize 'MIST_ENGINE.OVERCOME.LimitReachedHint'}}">{{localize 'MIST_ENGINE.OVERCOME.Overcome'}}</span>{{/if}}</div>
     </div>
+    {{!-- challenge.floatingTagsAndStatuses is a sorted VIEW (tags before
+    statuses; see FloatingTagAndStatusAdapter.sortedFloatingView, issue #28) -
+    each entry carries its ORIGINAL position in the persisted array as
+    `originalIndex`, which is what data-index must use so handlers keep
+    mutating the right element. Do not switch this back to @index. --}}
     {{#if challenge.hasFloatingTagsAndStatuses}}
     <div class="floating-tags-and-status-entries">
-        {{#each challenge.floatingTagsAndStatuses as |fts ftsIndex|}}
-        <div class="floating-tag-and-status-entry flexcol" data-might="{{this.might}}" data-index="{{@index}}" data-actor-id="{{../challenge.id}}" data-token-id="{{../challenge.tokenId}}" data-is-status="{{fts.isStatus}}">
+        {{#each challenge.floatingTagsAndStatuses as |fts|}}
+        <div class="floating-tag-and-status-entry flexcol" data-might="{{this.might}}" data-index="{{fts.originalIndex}}" data-actor-id="{{../challenge.id}}" data-token-id="{{../challenge.tokenId}}" data-is-status="{{fts.isStatus}}">
             <div class="flexrow">
 
                 <div class="fts-input-name fts-tag-status-toggle-actor {{#if fts.isStatus}}status{{else}}tag{{/if}} {{#if this.positive}}positive{{else}}negative{{/if}}"
-                    data-index="{{ftsIndex}}" data-actor-id="{{../challenge.id}}" data-token-id="{{../challenge.tokenId}}"
+                    data-index="{{fts.originalIndex}}" data-actor-id="{{../challenge.id}}" data-token-id="{{../challenge.tokenId}}"
                     title="right click to toggle between tag or state">
-                    <i class="fa-solid {{#if this.positive}}fa-thumbs-up{{else}}fa-thumbs-down{{/if}} fts-tag-modifier-toggle" data-action="toggleFloatingTagOrStatusModifier" data-source="litm-npc" data-index="{{@index}}" data-actor-id="{{../challenge.id}}" data-token-id="{{../challenge.tokenId}}" title="toggle between positive and negative"></i>
-                     <span class="fts-selectable {{#if this.selected}}selected{{/if}}" data-action="toggleFloatingTagOrStatusSelected" data-index="{{@index}}" data-source="litm-npc" data-actor-id="{{../challenge.id}}" data-token-id="{{../challenge.tokenId}}">
+                    <i class="fa-solid {{#if this.positive}}fa-thumbs-up{{else}}fa-thumbs-down{{/if}} fts-tag-modifier-toggle" data-action="toggleFloatingTagOrStatusModifier" data-source="litm-npc" data-index="{{fts.originalIndex}}" data-actor-id="{{../challenge.id}}" data-token-id="{{../challenge.tokenId}}" title="toggle between positive and negative"></i>
+                     <span class="fts-selectable {{#if this.selected}}selected{{/if}}" data-action="toggleFloatingTagOrStatusSelected" data-index="{{fts.originalIndex}}" data-source="litm-npc" data-actor-id="{{../challenge.id}}" data-token-id="{{../challenge.tokenId}}">
                         {{#if this.might}}<i class="might-icon {{this.mightIcon}}"></i>{{/if}}
                         {{this.name}}{{#if this.isStatus}}-{{this.value}}{{/if}}
                     </span>
-                    <i class="fa-solid fa-trash fts-tag-status-toggle" data-action="deleteFloatingTagOrStatus" data-index="{{@index}}" data-confirm="1" title="delete this tag/status" data-index="{{@index}}" data-source="litm-npc" data-actor-id="{{../challenge.id}}" data-token-id="{{../challenge.tokenId}}"></i>
-                    <i class="fa-solid fa-arrows-to-dot fts-tag-status-toggle" data-action="toggleFloatingTagOrStatus" data-index="{{@index}}" title="toggle between tag and status" data-index="{{@index}}" data-source="litm-npc" data-actor-id="{{../challenge.id}}" data-token-id="{{../challenge.tokenId}}"></i>
+                    <i class="fa-solid fa-trash fts-tag-status-toggle" data-action="deleteFloatingTagOrStatus" data-index="{{fts.originalIndex}}" data-confirm="1" title="delete this tag/status" data-source="litm-npc" data-actor-id="{{../challenge.id}}" data-token-id="{{../challenge.tokenId}}"></i>
+                    <i class="fa-solid fa-arrows-to-dot fts-tag-status-toggle" data-action="toggleFloatingTagOrStatus" data-index="{{fts.originalIndex}}" title="toggle between tag and status" data-source="litm-npc" data-actor-id="{{../challenge.id}}" data-token-id="{{../challenge.tokenId}}"></i>
                 </div>
 
             </div>
@@ -27,7 +32,7 @@
                 {{#each fts.markings as |marking index|}}
                 <span class="fts-input-marking" data-marking-index="{{index}}"
                     data-action="actorToggleFloatingTagOrStatusMarking" data-actor-id="{{../../challenge.id}}" data-token-id="{{../../challenge.tokenId}}"
-                    data-index="{{ftsIndex}}">
+                    data-index="{{fts.originalIndex}}">
                     <i class="marking-circle {{#if marking}}active{{else}}inactive{{/if}}">{{indexPlusOne
                         index}}</i>
                 </span>

--- a/templates/scene-app/_single_character.hbs
+++ b/templates/scene-app/_single_character.hbs
@@ -2,22 +2,27 @@
     <div class="npc-subtitle-container-c">
         <div class="npc-subtitle-text pointer" data-action="clickOpenCharacterSheet" data-id="{{character.id}}"><img src="{{character.img}}" alt="{{character.name}}" class="actor-img"> {{character.name}}</div>
     </div>
+    {{!-- character.floatingTagsAndStatuses is a sorted VIEW (tags before
+    statuses; see FloatingTagAndStatusAdapter.sortedFloatingView, issue #28) -
+    each entry carries its ORIGINAL position in the persisted array as
+    `originalIndex`, which is what data-index must use so handlers keep
+    mutating the right element. Do not switch this back to @index. --}}
     {{#if character.hasFloatingTagsAndStatuses}}
     <div class="floating-tags-and-status-entries">
-        {{#each character.floatingTagsAndStatuses as |fts ftsIndex|}}
-        <div class="floating-tag-and-status-entry flexcol" data-might="{{this.might}}" data-index="{{@index}}" data-actor-id="{{../character.id}}" data-is-status="{{fts.isStatus}}">
+        {{#each character.floatingTagsAndStatuses as |fts|}}
+        <div class="floating-tag-and-status-entry flexcol" data-might="{{this.might}}" data-index="{{fts.originalIndex}}" data-actor-id="{{../character.id}}" data-is-status="{{fts.isStatus}}">
             <div class="flexrow">
 
                 <div class="fts-input-name fts-tag-status-toggle-actor {{#if fts.isStatus}}status{{else}}tag{{/if}} {{#if this.positive}}positive{{else}}negative{{/if}}"
-                    data-index="{{ftsIndex}}" data-actor-id="{{../character.id}}"
+                    data-index="{{fts.originalIndex}}" data-actor-id="{{../character.id}}"
                     title="right click to toggle between tag or state">
-                    <i class="fa-solid {{#if this.positive}}fa-thumbs-up{{else}}fa-thumbs-down{{/if}} fts-tag-modifier-toggle" data-action="toggleFloatingTagOrStatusModifier" data-source="litm-character" data-index="{{@index}}" data-actor-id="{{../character.id}}" title="toggle between positive and negative"></i>
-                    <span class="fts-selectable {{#if this.selected}}selected{{/if}}" data-action="toggleFloatingTagOrStatusSelected" data-source="litm-character" data-index="{{@index}}" data-actor-id="{{../character.id}}" title="{{floatingTagStatusTitleHelper this}}">
+                    <i class="fa-solid {{#if this.positive}}fa-thumbs-up{{else}}fa-thumbs-down{{/if}} fts-tag-modifier-toggle" data-action="toggleFloatingTagOrStatusModifier" data-source="litm-character" data-index="{{fts.originalIndex}}" data-actor-id="{{../character.id}}" title="toggle between positive and negative"></i>
+                    <span class="fts-selectable {{#if this.selected}}selected{{/if}}" data-action="toggleFloatingTagOrStatusSelected" data-source="litm-character" data-index="{{fts.originalIndex}}" data-actor-id="{{../character.id}}" title="{{floatingTagStatusTitleHelper this}}">
                     {{#if this.might}}<i class="might-icon {{this.mightIcon}}"></i>{{/if}}
                     {{fts.name}}{{#if fts.isStatus}}-{{fts.value}}{{/if}}
                     </span>
-                    <i class="fa-solid fa-trash fts-tag-status-toggle" data-action="deleteFloatingTagOrStatus" data-index="{{@index}}" data-confirm="1" title="delete this tag/status" data-source="litm-character" data-index="{{@index}}" data-actor-id="{{../character.id}}"></i>
-                    <i class="fa-solid fa-arrows-to-dot fts-tag-status-toggle" data-action="toggleFloatingTagOrStatus" data-index="{{@index}}" title="toggle between tag and status" data-source="litm-character" data-index="{{@index}}"  data-actor-id="{{../character.id}}"></i>
+                    <i class="fa-solid fa-trash fts-tag-status-toggle" data-action="deleteFloatingTagOrStatus" data-index="{{fts.originalIndex}}" data-confirm="1" title="delete this tag/status" data-source="litm-character" data-actor-id="{{../character.id}}"></i>
+                    <i class="fa-solid fa-arrows-to-dot fts-tag-status-toggle" data-action="toggleFloatingTagOrStatus" data-index="{{fts.originalIndex}}" title="toggle between tag and status" data-source="litm-character" data-actor-id="{{../character.id}}"></i>
                 </div>
             </div>
             {{#if fts.isStatus}}
@@ -26,7 +31,7 @@
                 {{#each fts.markings as |marking index|}}
                 <span class="fts-input-marking" data-marking-index="{{index}}"
                     data-action="actorToggleFloatingTagOrStatusMarking" data-actor-id="{{../../character.id}}"
-                    data-index="{{ftsIndex}}">
+                    data-index="{{fts.originalIndex}}">
                     <i class="marking-circle {{#if marking}}active{{else}}inactive{{/if}}">{{indexPlusOne
                         index}}</i>
                 </span>

--- a/templates/scene-app/tags.hbs
+++ b/templates/scene-app/tags.hbs
@@ -1,4 +1,4 @@
 <section id="{{partId}}">
         {{> 'systems/mist-engine-fvtt/templates/shared/floating-tags-and-status-partial.hbs'
-                floatingTagsAndStatuses=currentSceneDataItem.system.floatingTagsAndStatuses floatingTagsAndStatusesEditable=currentSceneDataItem.system.floatingTagsAndStatusesEditable gmCheck=true useGrid=true}}
+                floatingTagsAndStatuses=sortedFloatingTagsAndStatuses floatingTagsAndStatusesEditable=currentSceneDataItem.system.floatingTagsAndStatusesEditable gmCheck=true useGrid=true}}
 </section>

--- a/templates/shared/floating-tags-and-status-partial.hbs
+++ b/templates/shared/floating-tags-and-status-partial.hbs
@@ -23,30 +23,35 @@
 </div>
 
 <div class="floating-tags-and-status-entries {{#if useGrid}}grid grid-3col{{/if}}">
+    {{!-- floatingTagsAndStatuses is a sorted VIEW (tags before statuses; see
+    FloatingTagAndStatusAdapter.sortedFloatingView, issue #28) - each entry
+    carries its ORIGINAL position in the persisted array as `originalIndex`,
+    which is what data-index must use so handlers keep mutating the right
+    element. Do not switch this back to @index. --}}
     {{#each floatingTagsAndStatuses}}
-    <div class="floating-tag-and-status-entry flexcol" data-might="{{this.might}}" data-index="{{@index}}" data-is-status="{{this.isStatus}}">
+    <div class="floating-tag-and-status-entry flexcol" data-might="{{this.might}}" data-index="{{this.originalIndex}}" data-is-status="{{this.isStatus}}">
         {{!-- Tag/Status --}}
-        <div class="fts-tag-container" data-might="{{this.might}}" data-index="{{@index}}" data-is-status="{{this.isStatus}}">
+        <div class="fts-tag-container" data-might="{{this.might}}" data-index="{{this.originalIndex}}" data-is-status="{{this.isStatus}}">
             {{#if ../floatingTagsAndStatusesEditable}}
             {{! -- this input field must not have a name attribute! otterwise foundry itself will update the array and fills it fill false data! --}}
-            <input type="text" class="fts-input-name updateable-fts-stat" data-index="{{@index}}" data-key="name"
+            <input type="text" class="fts-input-name updateable-fts-stat" data-index="{{this.originalIndex}}" data-key="name"
                 value="{{this.name}}" placeholder="{{localize 'MIST_ENGINE.LABELS.Item.TagStatusName'}}">
             {{#if this.isStatus}}
             <input type="text" class="fts-input-value" value="{{this.value}}" disabled>
             {{/if}}
-            <a data-action="deleteFloatingTagOrStatus" data-index="{{@index}}"><i class='fas fa-trash'></i></a>
+            <a data-action="deleteFloatingTagOrStatus" data-index="{{this.originalIndex}}"><i class='fas fa-trash'></i></a>
             {{else}}
             <div class="fts-input-name  {{#if this.isStatus}}status{{else}}tag{{/if}} {{#if this.positive}}positive{{else}}negative{{/if}}">
                 {{#if (isRenderBlockAllowed ../gmCheck)}}
-                    <i class="fa-solid {{#if this.positive}}fa-thumbs-up{{else}}fa-thumbs-down{{/if}} fts-tag-modifier-toggle" data-action="toggleFloatingTagOrStatusModifier" data-index="{{@index}}" title="toggle between positive and negative"></i>
+                    <i class="fa-solid {{#if this.positive}}fa-thumbs-up{{else}}fa-thumbs-down{{/if}} fts-tag-modifier-toggle" data-action="toggleFloatingTagOrStatusModifier" data-index="{{this.originalIndex}}" title="toggle between positive and negative"></i>
                 {{/if}}
-                <span class="fts-selectable {{#if this.selected}}selected{{/if}}" data-action="toggleFloatingTagOrStatusSelected" data-index="{{@index}}" title="{{floatingTagStatusTitleHelper this}}">
+                <span class="fts-selectable {{#if this.selected}}selected{{/if}}" data-action="toggleFloatingTagOrStatusSelected" data-index="{{this.originalIndex}}" title="{{floatingTagStatusTitleHelper this}}">
                     {{#if this.might}}<i class="might-icon {{this.mightIcon}}"></i>{{/if}}
                     {{this.name}}{{#if this.isStatus}}-{{this.value}}{{/if}}
                 </span>
                 {{#if (isRenderBlockAllowed ../gmCheck)}}
-                    <i class="fa-solid fa-trash fts-tag-status-toggle" data-action="deleteFloatingTagOrStatus" data-index="{{@index}}" data-confirm="1" title="delete this tag/status"></i>
-                    <i class="fa-solid fa-arrows-to-dot fts-tag-status-toggle" data-action="toggleFloatingTagOrStatus" data-index="{{@index}}" title="toggle between tag and status"></i>
+                    <i class="fa-solid fa-trash fts-tag-status-toggle" data-action="deleteFloatingTagOrStatus" data-index="{{this.originalIndex}}" data-confirm="1" title="delete this tag/status"></i>
+                    <i class="fa-solid fa-arrows-to-dot fts-tag-status-toggle" data-action="toggleFloatingTagOrStatus" data-index="{{this.originalIndex}}" title="toggle between tag and status"></i>
                 {{/if}}
             </div>
             {{/if}}
@@ -57,7 +62,7 @@
         <div class="fts-markings-container">
             {{#each this.markings as |marking index|}}
             <span class="fts-input-marking" data-marking-index="{{index}}"
-                data-action="toggleFloatingTagOrStatusMarking" data-index="{{@../index}}">
+                data-action="toggleFloatingTagOrStatusMarking" data-index="{{../originalIndex}}">
                 <i class="marking-circle {{#if marking}}active{{else}}inactive{{/if}}">{{indexPlusOne index}}</i>
             </span>
             {{/each}}


### PR DESCRIPTION
Fixes #28

Sheets rendered system.floatingTagsAndStatuses in raw insertion order,
so a tag added after a status (or vice versa) produced a visually
jumbled list. Sorting now happens only in a display-only view built at
context-prep time (FloatingTagAndStatusAdapter.sortedFloatingView):
tags first, then statuses, stable within each group. Every entry in
that view carries its original array index as originalIndex, and every
consumer template (character sheet, NPC sheet, scene app) now keys
data-index off that instead of the render-order index, since every
click/toggle/delete handler and the GM right-click menu mutate the
persisted array by index. The persisted array itself is never
reordered.
