### PR TITLE
feat: filter theme kit list by launching theme book (#102)

### DIFF
--- a/css/mist-engine-fvtt.css
+++ b/css/mist-engine-fvtt.css
@@ -4613,6 +4613,26 @@ article.cc-enriched section.journal-entry-content {
   align-self: flex-start;
   height: 100%;
 }
+#themekit-selection-app > section.window-content .left-panel .themekit-filter-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  margin-bottom: 6px;
+  padding: 4px 6px;
+  background-color: rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--litm-color-accent);
+  border-radius: 3px;
+  color: var(--litm-color-accent);
+  font-family: Labrada, serif;
+  font-size: 0.8em;
+}
+#themekit-selection-app > section.window-content .left-panel .themekit-filter-banner .themekit-filter-toggle {
+  color: var(--litm-color-accent);
+  text-decoration: underline;
+  cursor: pointer;
+  white-space: nowrap;
+}
 #themekit-selection-app > section.window-content .left-panel .themekit-search {
   width: 100%;
   margin-bottom: 6px;

--- a/lang/de.json
+++ b/lang/de.json
@@ -134,6 +134,13 @@
         "NOTIFICATIONS": {
             "NoCharacterAssignedForThemekitSelection": "Kein Charakter zugewiesen. Weise deinem Benutzer einen Charakter zu, um die Theme-Kit-Auswahl zu öffnen."
         },
+        "THEMEKITS": {
+            "NoThemekitsForThemebook": "Keine Themekits gehören zum Themebook „{themebook}“. Nutze „Alle anzeigen“, um alle verfügbaren Kits zu sehen.",
+            "FilteredForThemebook": "Zeigt Kits für „{themebook}“",
+            "ShowAllThemekits": "Alle anzeigen",
+            "ShowingAllThemekits": "Alle Themekits werden angezeigt",
+            "ShowFilteredThemekits": "Nur „{themebook}“ anzeigen"
+        },
         "SCENE_APP": {
             "Title": "Szenen-Tags",
             "NoActiveScene": "Der Szenen-Tracker benötigt eine aktive Szene. Aktiviere zuerst eine Szene."

--- a/lang/en.json
+++ b/lang/en.json
@@ -28,7 +28,12 @@
       "SelectThemekit": "Select Themekit",
       "RemoveThemekit": "Remove Themekit from Character",
       "AssignThemekit": "Assign Themekit",
-      "NoThemekitsAvailable": "No themekits available. Create themekit items first."
+      "NoThemekitsAvailable": "No themekits available. Create themekit items first.",
+      "NoThemekitsForThemebook": "No themekits belong to the \"{themebook}\" Themebook. Use \"Show all\" to see every available kit.",
+      "FilteredForThemebook": "Showing kits for \"{themebook}\"",
+      "ShowAllThemekits": "Show all",
+      "ShowingAllThemekits": "Showing all themekits",
+      "ShowFilteredThemekits": "Show only \"{themebook}\""
     },
     "SETTINGS": {
       "ThemekitSourcePacks": {

--- a/module/apps/themekit-selection-app.mjs
+++ b/module/apps/themekit-selection-app.mjs
@@ -9,10 +9,47 @@ const FILTER_DATASET_KEYS = {
     story:                'searchStory',
 };
 
+/**
+ * Filters a flat list of themekit documents down to those belonging to the
+ * launching themebook (issue #102).
+ *
+ * A kit "belongs to" a themebook by name: `system.themekit_type` holds the
+ * name of the themebook the kit fills in (e.g. "Skill or Trade" — the
+ * adapter uses it as the created themebook's name). Matching is trimmed and
+ * case-insensitive. Note `system.themebook_type` is NOT the themebook — it
+ * is the might level (litm-origin/adventure/greatness) and plays no part
+ * here: two books of the same might are still different books.
+ *
+ * Kits with a blank/empty `system.themekit_type` are always kept — they
+ * predate this field and are treated as legacy content that should stay
+ * visible regardless of which themebook opened the app.
+ *
+ * When `themebookName` is blank/falsy (no launching themebook — nothing to
+ * filter against) or `showAll` is true (user hit the "show all" escape
+ * hatch), the list passes through unfiltered.
+ *
+ * Pure function, no Foundry API dependency, so it can be exercised by a
+ * standalone Node script without stubbing the Foundry runtime.
+ *
+ * @param {Array<object>} themekits                Themekit documents (or plain objects with a `system.themekit_type`).
+ * @param {string|null|undefined} themebookName    The launching themebook's name (e.g. "Skill or Trade"), or blank/falsy to disable filtering.
+ * @param {boolean} [showAll=false]                Escape hatch — when true, disables filtering regardless of `themebookName`.
+ * @returns {Array<object>}
+ */
+export function filterThemekitsForThemebook(themekits, themebookName, showAll = false) {
+    const bookName = themebookName?.trim().toLowerCase();
+    if (!bookName || showAll) return themekits;
+    return themekits.filter(themekit => {
+        const kitBookName = themekit?.system?.themekit_type?.trim().toLowerCase();
+        return !kitBookName || kitBookName === bookName;
+    });
+}
+
 export class ThemekitSelectionApp extends HandlebarsApplicationMixin(ApplicationV2) {
     currentSelectedThemekit = null;
     actor = null;
     actorThemebook = null;
+    showAllThemekits = false;
     _searchQuery = '';
     _activeFilters = new Set();
 
@@ -34,7 +71,8 @@ export class ThemekitSelectionApp extends HandlebarsApplicationMixin(Application
         },
         actions: {
             selectThemekit: this.#handleSelectThemekit,
-            addThemekit: this.#handleAddThemekit
+            addThemekit: this.#handleAddThemekit,
+            toggleShowAllThemekits: this.#handleToggleShowAllThemekits
         },
     };
 
@@ -64,10 +102,19 @@ export class ThemekitSelectionApp extends HandlebarsApplicationMixin(Application
         }else{
             context.addThemekitButtonStr = game.i18n.localize("MIST_ENGINE.THEMEKITS.AddThemekit");
         }
-        
+
+        // Issue #102: when opened from a themebook card, offer to filter the
+        // list down to kits belonging to that themebook (matched by name),
+        // with a toggle to escape it.
+        const themebookName = this.actorThemebook?.name?.trim() || null;
+        context.hasThemebookFilter = Boolean(themebookName);
+        context.isFilteredByThemebook = context.hasThemebookFilter && !this.showAllThemekits;
+        context.showAllThemekits = this.showAllThemekits;
+        context.themebookFilterLabel = themebookName;
+
         // we set this flag if the currentSelectedThemekit has any special improvements without an empty name
         context.hasSpecialImprovements = context.currentSelectedThemekitAvailable && context.currentSelectedThemekit.system.specialImprovements && context.currentSelectedThemekit.system.specialImprovements.some(si => si.name && si.name.trim() !== "");
-        
+
         return context;
     }
 
@@ -109,10 +156,14 @@ export class ThemekitSelectionApp extends HandlebarsApplicationMixin(Application
         ...compendiumThemeKits
         ];
 
+        // Issue #102: filter to kits belonging to the launching themebook
+        // (blank themekit_type kits and the "show all" toggle both bypass this).
+        const filteredThemeKits = filterThemekitsForThemebook(allThemeKits, this.actorThemebook?.name, this.showAllThemekits);
+
         // now we group them by property 'themekit_type', if themekit_type in uppercase is not set, we put it in a group called 'OTHER'
         // each group hash is {groupName: string, themekits: array of themekits}
         const themekitsByType = {};
-        for(let themekit of allThemeKits){
+        for(let themekit of filteredThemeKits){
             const type = (themekit.system.themekit_type || "OTHER").toUpperCase(); 
             if(!themekitsByType[type]){
                 themekitsByType[type] = { groupName: type, themekits: [] };
@@ -188,6 +239,12 @@ export class ThemekitSelectionApp extends HandlebarsApplicationMixin(Application
 
     setThemebook(themebook){
         this.actorThemebook = themebook;
+    }
+
+    static async #handleToggleShowAllThemekits(event, target){
+        event.preventDefault();
+        this.showAllThemekits = !this.showAllThemekits;
+        this.render();
     }
 
     static async #handleAddThemekit(event, target){

--- a/src/scss/components/_themekit_selection_app.scss
+++ b/src/scss/components/_themekit_selection_app.scss
@@ -14,6 +14,28 @@
         align-self:flex-start;
         height: 100%;
 
+        .themekit-filter-banner {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 6px;
+            margin-bottom: 6px;
+            padding: 4px 6px;
+            background-color: rgba(0, 0, 0, 0.2);
+            border: 1px solid var(--litm-color-accent);
+            border-radius: 3px;
+            color: var(--litm-color-accent);
+            font-family: $font-primary;
+            font-size: 0.8em;
+
+            .themekit-filter-toggle {
+                color: var(--litm-color-accent);
+                text-decoration: underline;
+                cursor: pointer;
+                white-space: nowrap;
+            }
+        }
+
         .themekit-search {
             width: 100%;
             margin-bottom: 6px;

--- a/templates/themekit-selection-app/left.hbs
+++ b/templates/themekit-selection-app/left.hbs
@@ -1,4 +1,15 @@
 <div class="left-panel scrollable">
+    {{#if hasThemebookFilter}}
+    <div class="themekit-filter-banner">
+        {{#if isFilteredByThemebook}}
+        <span>{{localize "MIST_ENGINE.THEMEKITS.FilteredForThemebook" themebook=themebookFilterLabel}}</span>
+        <a class="themekit-filter-toggle" data-action="toggleShowAllThemekits">{{localize "MIST_ENGINE.THEMEKITS.ShowAllThemekits"}}</a>
+        {{else}}
+        <span>{{localize "MIST_ENGINE.THEMEKITS.ShowingAllThemekits"}}</span>
+        <a class="themekit-filter-toggle" data-action="toggleShowAllThemekits">{{localize "MIST_ENGINE.THEMEKITS.ShowFilteredThemekits" themebook=themebookFilterLabel}}</a>
+        {{/if}}
+    </div>
+    {{/if}}
     <input type="text" class="themekit-search" placeholder="Search themekits...">
     <div class="search-filters">
         <label class="search-filter-toggle"><input type="checkbox" data-filter="powertags"> Power Tags</label>

--- a/templates/themekit-selection-app/right.hbs
+++ b/templates/themekit-selection-app/right.hbs
@@ -1,7 +1,11 @@
 <div class="right-panel scrollable">
             <div class="">
                 {{#if (eq hasAvailableThemekits false)}}
+                {{#if isFilteredByThemebook}}
+                <p>{{localize "MIST_ENGINE.THEMEKITS.NoThemekitsForThemebook" themebook=themebookFilterLabel}}</p>
+                {{else}}
                 <p>{{localize "MIST_ENGINE.THEMEKITS.NoThemekitsAvailable"}}</p>
+                {{/if}}
                 {{/if}}
                 {{#if currentSelectedThemekitAvailable}}
                 <h2>{{currentSelectedThemekit.name}}</h2>


### PR DESCRIPTION
Fixes #102 

ThemekitSelectionApp now filters its kit list to kits whose
system.themebook_type matches the launching themebook's system.type when
opened from a themebook card (setThemebook()). Kits with a blank
themebook_type stay visible (legacy content), and a "showing kits for
<type> — show all" toggle in the left panel lets users escape the filter.
Opening from the menu/hotkey (no themebook set) is unaffected and still
shows everything. Filter logic is extracted into a pure, stub-tested
filterThemekitsForThemebook() export.
