### PR TITLE
feat: [/sn] syntax for negative statuses (#81)

### DIFF
--- a/css/mist-engine-fvtt.css
+++ b/css/mist-engine-fvtt.css
@@ -369,7 +369,8 @@ body {
 .tab-notes mark.tag.green {
   background: linear-gradient(to bottom, transparent 20%, rgb(188, 205, 175) 21%, rgb(188, 205, 175) 90%, transparent 91%);
 }
-.editor-content mark.weakness, .editor-content mark.tag.orange,
+.editor-content mark.status.negative, .editor-content mark.weakness, .editor-content mark.tag.orange,
+.tab-notes mark.status.negative,
 .tab-notes mark.weakness,
 .tab-notes mark.tag.orange {
   background: linear-gradient(to bottom, transparent 20%, rgb(236, 186, 133) 21%, rgb(236, 186, 133) 90%, transparent 91%);
@@ -665,7 +666,7 @@ body {
 .journal-entry-content mark.status, .journal-entry-content mark.tag.green {
   background: linear-gradient(to bottom, transparent 20%, rgb(188, 205, 175) 21%, rgb(188, 205, 175) 90%, transparent 91%);
 }
-.journal-entry-content mark.weakness, .journal-entry-content mark.tag.orange {
+.journal-entry-content mark.status.negative, .journal-entry-content mark.weakness, .journal-entry-content mark.tag.orange {
   background: linear-gradient(to bottom, transparent 20%, rgb(236, 186, 133) 21%, rgb(236, 186, 133) 90%, transparent 91%);
 }
 .journal-entry-content mark.limit, .journal-entry-content mark.tag.red {
@@ -1654,7 +1655,7 @@ article.cc-enriched section.journal-entry-content {
 .mist-engine #tooltip mark.status, .mist-engine #tooltip mark.tag.green {
   background: linear-gradient(to bottom, transparent 20%, rgb(188, 205, 175) 21%, rgb(188, 205, 175) 90%, transparent 91%);
 }
-.mist-engine #tooltip mark.weakness, .mist-engine #tooltip mark.tag.orange {
+.mist-engine #tooltip mark.status.negative, .mist-engine #tooltip mark.weakness, .mist-engine #tooltip mark.tag.orange {
   background: linear-gradient(to bottom, transparent 20%, rgb(236, 186, 133) 21%, rgb(236, 186, 133) 90%, transparent 91%);
 }
 .mist-engine #tooltip mark.limit, .mist-engine #tooltip mark.tag.red {
@@ -2340,6 +2341,11 @@ article.cc-enriched section.journal-entry-content {
 .mist-engine .fts-input-name.negative {
   background-color: rgb(236, 186, 133);
 }
+.mist-engine .fts-input-name.status.negative {
+  background-color: rgb(236, 186, 133);
+  border: 1px solid rgba(100, 55, 8, 0.55);
+  box-shadow: inset 0 1px 2px rgba(255, 205, 90, 0.12), inset 0 -1px 2px rgba(60, 30, 5, 0.15);
+}
 .mist-engine .fts-input-value {
   flex-shrink: 2;
 }
@@ -2774,7 +2780,7 @@ article.cc-enriched section.journal-entry-content {
 .mist-engine mark.status, .mist-engine mark.tag.green {
   background: linear-gradient(to bottom, transparent 20%, rgb(188, 205, 175) 21%, rgb(188, 205, 175) 90%, transparent 91%);
 }
-.mist-engine mark.weakness, .mist-engine mark.tag.orange {
+.mist-engine mark.status.negative, .mist-engine mark.weakness, .mist-engine mark.tag.orange {
   background: linear-gradient(to bottom, transparent 20%, rgb(236, 186, 133) 21%, rgb(236, 186, 133) 90%, transparent 91%);
 }
 .mist-engine mark.limit, .mist-engine mark.tag.red {
@@ -3529,7 +3535,7 @@ article.cc-enriched section.journal-entry-content {
 .message-content mark.status, .message-content mark.tag.green {
   background: linear-gradient(to bottom, transparent 20%, rgb(188, 205, 175) 21%, rgb(188, 205, 175) 90%, transparent 91%);
 }
-.message-content mark.weakness, .message-content mark.tag.orange {
+.message-content mark.status.negative, .message-content mark.weakness, .message-content mark.tag.orange {
   background: linear-gradient(to bottom, transparent 20%, rgb(236, 186, 133) 21%, rgb(236, 186, 133) 90%, transparent 91%);
 }
 .message-content mark.limit, .message-content mark.tag.red {
@@ -3798,6 +3804,9 @@ article.cc-enriched section.journal-entry-content {
 }
 .roll-dialog-container .selected-tags-container .status.positive {
   background-color: rgb(188, 205, 175);
+}
+.roll-dialog-container .selected-tags-container .status.negative {
+  background-color: rgb(236, 186, 133);
 }
 .roll-dialog-container .selected-tags-container .tag-icon {
   float: left;
@@ -4194,7 +4203,7 @@ article.cc-enriched section.journal-entry-content {
 .scene-app .scene-story-themes .scene-story-theme .scene-story-theme-tags mark.status, .scene-app .scene-story-themes .scene-story-theme .scene-story-theme-tags mark.tag.green {
   background: linear-gradient(to bottom, transparent 20%, rgb(188, 205, 175) 21%, rgb(188, 205, 175) 90%, transparent 91%);
 }
-.scene-app .scene-story-themes .scene-story-theme .scene-story-theme-tags mark.weakness, .scene-app .scene-story-themes .scene-story-theme .scene-story-theme-tags mark.tag.orange {
+.scene-app .scene-story-themes .scene-story-theme .scene-story-theme-tags mark.status.negative, .scene-app .scene-story-themes .scene-story-theme .scene-story-theme-tags mark.weakness, .scene-app .scene-story-themes .scene-story-theme .scene-story-theme-tags mark.tag.orange {
   background: linear-gradient(to bottom, transparent 20%, rgb(236, 186, 133) 21%, rgb(236, 186, 133) 90%, transparent 91%);
 }
 .scene-app .scene-story-themes .scene-story-theme .scene-story-theme-tags mark.limit, .scene-app .scene-story-themes .scene-story-theme .scene-story-theme-tags mark.tag.red {

--- a/module/apps/scene-app.mjs
+++ b/module/apps/scene-app.mjs
@@ -280,7 +280,7 @@ export class MistSceneApp extends HandlebarsApplicationMixin(ApplicationV2) {
      */
     async _onDrop(event) {
         const data = TextEditor.getDragEventData(event);
-        const { type, name, value } = data;
+        const { type, name, value, positive } = data;
 
         if (type === "Actor" && game.user.isGM) {
             const actor = await fromUuid(data.uuid);
@@ -329,10 +329,13 @@ export class MistSceneApp extends HandlebarsApplicationMixin(ApplicationV2) {
             case "status":
                 const markings = new Array(6).fill(false);
                 markings[Math.max(0, Math.min(parseInt(value) - 1, 5))] = true;
+                // data-positive is absent for existing (positive) statuses; only an
+                // explicit "false" (from the [/sn] negative-status token) flips it
+                const statusPositive = positive !== "false";
                 await this.currentSceneDataItem.update({
                     "system.floatingTagsAndStatuses": FloatingTagAndStatusAdapter.withStatusStacked(
                         floatingTagsAndStatuses,
-                        { name, value, isStatus, markings }
+                        { name, value, isStatus, markings, positive: statusPositive }
                     ),
                 });
                 this.sendUpdateHookEvent();
@@ -813,7 +816,7 @@ export class MistSceneApp extends HandlebarsApplicationMixin(ApplicationV2) {
         try {
             promptResult = await foundry.applications.api.DialogV2.prompt({
                 window: { title: "Enter the status or tag" },
-                content: `<input name="srcStatusTagStr" type="text" autofocus placeholder="tag or status-2">
+                content: `<input name="srcStatusTagStr" type="text" autofocus placeholder="tag or status-2 (or /sn status-2 for negative)">
                 <div class="form-group"><label><input name="negative" type="checkbox"> ${game.i18n.localize("MIST_ENGINE.LABELS.CreateAsNegative")}</label></div>`,
                 ok: {
                     label: "Submit",

--- a/module/lib/floating-tag-and-status-adapter.mjs
+++ b/module/lib/floating-tag-and-status-adapter.mjs
@@ -15,7 +15,11 @@ export class FloatingTagAndStatusAdapter {
      * tracking-card rule (Core Book p. 29): a same-named status marks the box
      * of its tier; if that box is already marked, the next empty box to the
      * right is marked instead. The status tier is the highest marked box.
-     * Non-statuses and new names are simply appended.
+     * Non-statuses and new names are simply appended. A same-named status of
+     * the *opposite* polarity (e.g. a negative "dazed" dropped onto an
+     * existing positive "dazed") is never stacked onto the existing entry —
+     * that would silently flip its polarity and corrupt roll math — it is
+     * instead appended as its own separate entry.
      * @param {Array} list        current floatingTagsAndStatuses array
      * @param {object} ftsObject  entry to add (from parseFloatingTagAndStatusString or a drop)
      * @returns {Array} a new array with the entry appended or stacked
@@ -23,8 +27,15 @@ export class FloatingTagAndStatusAdapter {
     static withStatusStacked(list, ftsObject){
         const current = list ?? [];
         const norm = s => String(s ?? "").trim().toLowerCase();
+        // missing/undefined `positive` defaults to true, matching the schema
+        // default (module/data/util.mjs) - compare both sides on that basis
+        const isPositive = v => v !== false;
         if (ftsObject.isStatus && norm(ftsObject.name) !== "") {
-            const idx = current.findIndex(e => e.isStatus && norm(e.name) === norm(ftsObject.name));
+            const idx = current.findIndex(e =>
+                e.isStatus &&
+                norm(e.name) === norm(ftsObject.name) &&
+                isPositive(e.positive) === isPositive(ftsObject.positive)
+            );
             if (idx !== -1) {
                 const existing = foundry.utils.deepClone(current[idx]);
                 const markings = [...(existing.markings ?? Array(6).fill(false))];
@@ -45,9 +56,18 @@ export class FloatingTagAndStatusAdapter {
     }
 
     static parseFloatingTagAndStatusString(srcString){
-        let ftsObject = { name: srcString, description: "", isStatus: false, positive:true, value: 0, markings: Array(6).fill(false) };
-        if (srcString.includes("-")) {
-            const parts = srcString.split("-");
+        // A leading "/sn" marks the entry as a negative status/tag, mirroring
+        // the [/sn name-X] enricher token used in journal/description text.
+        let str = srcString.trim();
+        let positive = true;
+        if (str.startsWith("/sn")) {
+            positive = false;
+            str = str.slice(3).trim();
+        }
+
+        let ftsObject = { name: str, description: "", isStatus: false, positive, value: 0, markings: Array(6).fill(false) };
+        if (str.includes("-")) {
+            const parts = str.split("-");
             ftsObject.isStatus = true;
             ftsObject.value = parseInt(parts[parts.length - 1]) || 0;
             ftsObject.name = parts.slice(0, parts.length - 1).join("-").trim();

--- a/module/lib/tag-status-text-helper.mjs
+++ b/module/lib/tag-status-text-helper.mjs
@@ -4,6 +4,8 @@
 // [/w weakness] - a weakness tag
 // [status-X] - a status with a tier of X (1-6)
 // [/s status] - a status without a tier, used in a journal for example
+// [/sn status] - a negative status without a tier
+// [/sn status-X] - a negative status with a tier of X (1-6), counted as -X in rolls
 // [/l limit] - a limit without a value, used in a journal for example
 // [/l limit-X] - a limit with the value X (1-6)
 
@@ -18,6 +20,7 @@ const MIGHT = 3;
 const BOLD = 4;
 const LIMIT = 5;
 const WEAKNESS = 6;
+const NEGATIVE_STATUS = 7;
 
 /**
  * Convert raw text with above markup tokens to text with HTML mark elements
@@ -101,8 +104,13 @@ export function makeStyledTagOrStatusText(markup) {
   let isOfType = TAG; // type is TAG by default
   let extraIcon = ""; // No extra icon prefix
 
-  // status
-  if (markup.includes("/s")) {
+  // negative status - checked before the plain status token since "/sn" also
+  // contains the substring "/s" and would otherwise be caught by that check
+  if (markup.includes("/sn")) {
+    isOfType = NEGATIVE_STATUS;
+    markup = markup.replace("/sn", "");
+  } else if (markup.includes("/s")) {
+    // status
     isOfType = STATUS;
     markup = markup.replace("/s", "");
   }
@@ -155,6 +163,8 @@ export function makeStyledTagOrStatusText(markup) {
     const name = markup.trim();
     if (isOfType === STATUS) {
       return `<mark class="draggable status" draggable="true" data-type="status" data-name="${name}" data-value="0">${name}</mark>`;
+    } else if (isOfType === NEGATIVE_STATUS) {
+      return `<mark class="draggable status negative" draggable="true" data-type="status" data-positive="false" data-name="${name}" data-value="0">${name}</mark>`;
     } else if (isOfType === WEAKNESS) {
       return `<mark class="draggable weakness" draggable="true" data-type="weakness" data-name="${name}">${extraIcon}${name}</mark>`;
     } else if (isOfType === LIMIT) {
@@ -172,6 +182,8 @@ export function makeStyledTagOrStatusText(markup) {
     const name = markup.substring(0, markup.lastIndexOf("-")).trim();
     if (isOfType === LIMIT) {
       return `<div class="limit-inline"><mark class="draggable limit" draggable="true" data-type="limit" data-name="${name}" data-value="${value}">${name}</mark><span class="limit-value">${value}</span></div>`;
+    } else if (isOfType === NEGATIVE_STATUS) {
+      return `<mark class="draggable status negative" draggable="true" data-type="status" data-positive="false" data-name="${name}" data-value="${value}">${name}-${value}</mark>`;
     } else {
       return `<mark class="draggable status" draggable="true" data-type="status" data-name="${name}" data-value="${value}">${name}-${value}</mark>`;
     }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -517,7 +517,7 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
         try {
             promptResult = await foundry.applications.api.DialogV2.prompt({
                 window: { title: "Enter the status or tag" },
-                content: `<input name="srcStatusTagStr" type="text" autofocus placeholder="tag or status-2">
+                content: `<input name="srcStatusTagStr" type="text" autofocus placeholder="tag or status-2 (or /sn status-2 for negative)">
                 <div class="form-group"><label><input name="negative" type="checkbox"> ${game.i18n.localize("MIST_ENGINE.LABELS.CreateAsNegative")}</label></div>`,
                 ok: {
                     label: "Submit",
@@ -861,11 +861,14 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
                 break;
             case 'status':
                 const value = parseInt(data.value) || 0;
+                // data-positive is absent for existing (positive) statuses; only an
+                // explicit "false" (from the [/sn] negative-status token) flips it
+                const positive = data.positive !== "false";
                 // stacks with an existing same-named status per the tracking-card rule (p. 29)
                 this.actor.update({
                     "system.floatingTagsAndStatuses": FloatingTagAndStatusAdapter.withStatusStacked(
                         floatingTagsAndStatuses,
-                        { name: data.name, isStatus: true, value, description: "", markings: Array(6).fill(false).fill(true, Math.max(value - 1, 0), value) }
+                        { name: data.name, isStatus: true, value, positive, description: "", markings: Array(6).fill(false).fill(true, Math.max(value - 1, 0), value) }
                     ),
                 });
                 break;

--- a/src/scss/components/_roll_dialog.scss
+++ b/src/scss/components/_roll_dialog.scss
@@ -48,6 +48,10 @@
             &.positive {
                 background-color: $c-tag-green;
             }
+
+            &.negative {
+                background-color: $c-tag-orange;
+            }
         }
 
         .tag-icon {

--- a/src/scss/components/_tags.scss
+++ b/src/scss/components/_tags.scss
@@ -370,6 +370,14 @@
     &.negative {
         background-color: $c-tag-orange;
     }
+
+    &.status.negative {
+        background-color: $c-tag-orange;
+        border: 1px solid rgba(100, 55, 8, 0.55);
+        box-shadow:
+            inset 0 1px 2px rgba(255, 205, 90, 0.12),
+            inset 0 -1px 2px rgba(60, 30, 5, 0.15);
+    }
 }
 
 .fts-input-value {

--- a/src/scss/utils/_mixins.scss
+++ b/src/scss/utils/_mixins.scss
@@ -19,6 +19,7 @@
       background: linear-gradient(to bottom, transparent 20%, $c-tag-green 21%, $c-tag-green 90%, transparent 91%);
     }
 
+    &.status.negative,
     &.weakness,
     &.tag.orange {
       background: linear-gradient(to bottom, transparent 20%, $c-tag-orange 21%, $c-tag-orange 90%, transparent 91%);


### PR DESCRIPTION
Fixes #81

Adds a /sn token to both the display markup parser
(makeStyledTagOrStatusText) and the create-status-string parser
(parseFloatingTagAndStatusString) for statuses that should count
against a roll rather than for it. Threads positive:false through the
two drag-drop sites (actor-sheet.mjs, scene-app.mjs) that build a
floating status from drag data, mirroring the existing weakness-drop
pattern. Adds a red-tinted SCSS variant for negative status marks/chips
in the editor/journal mixin, sheet chips, and roll dialog.
