### PR TITLE
feat: enrich challenge consequence fields — UUID links work (#73)

### DIFF
--- a/module/apps/scene-app.mjs
+++ b/module/apps/scene-app.mjs
@@ -1,5 +1,6 @@
 const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
 import { FloatingTagAndStatusAdapter } from "../lib/floating-tag-and-status-adapter.mjs";
+import { enrichShortChallenges, enrichTextWithTags } from "../lib/tag-status-text-helper.mjs";
 import { ArrayFieldAdapter } from "../lib/array-field-adapter.mjs";
 import { DiceRollApp } from "./dice-roll-app.mjs";
 
@@ -374,8 +375,12 @@ export class MistSceneApp extends HandlebarsApplicationMixin(ApplicationV2) {
             context.assignedJourney = journey;
             context.assignedJourneyName = journey?.name ?? "";
             context.assignedJourneySystem = journey?.system ?? null;
+            // Enriched so @UUID[...]{Label} links render here too (issue #73).
+            context.assignedJourneyGeneralConsequencesHTML = journey
+                ? await Promise.all((journey.system.generalConsequences ?? []).map((entry) => enrichTextWithTags(entry, journey)))
+                : [];
             context.assignedJourneyChallenges = journey
-                ? journey.items.filter(i => i.type === "shortchallenge")
+                ? await enrichShortChallenges(journey.items.filter(i => i.type === "shortchallenge"), journey)
                 : [];
 
             // Story Themes tab: themebooks dragged onto the scene, read-only,

--- a/module/lib/tag-status-text-helper.mjs
+++ b/module/lib/tag-status-text-helper.mjs
@@ -39,6 +39,59 @@ export function textWithTags(str) {
 }
 
 /**
+ * Convert a raw tag/status string into final display HTML with document links
+ * (issue #73).
+ *
+ * Order matters: `textWithTags` runs FIRST, while the string is still plain
+ * text. Its regex explicitly skips `@UUID[...]{...}` (and other
+ * `@word[...]{...}`) spans - it matches them only so its `[...]` tag-token
+ * branch cannot misfire on their brackets - so it hands back a string with
+ * `[tag]`/`[/s status]` tokens converted to `<mark>` HTML and any
+ * `@UUID[...]{...}` spans still untouched as plain text. `enrichHTML` then
+ * runs SECOND on that (now partially-HTML) string, converting the remaining
+ * `@UUID[...]{...}` spans into real content-link anchors while leaving the
+ * `<mark>` elements alone. Running the plain (non-DOM-aware) textWithTags
+ * regex over enrichHTML's output instead would be the riskier direction.
+ *
+ * @param {string} raw
+ * @param {foundry.abstract.Document} doc owns permissions (secrets), roll data
+ *   and relative UUID resolution for the enrichment
+ * @returns {Promise<string>}
+ */
+export async function enrichTextWithTags(raw, doc) {
+  if (!raw) return "";
+  return foundry.applications.ux.TextEditor.implementation.enrichHTML(textWithTags(raw), {
+    // Whether to show secret blocks in the finished html
+    secrets: doc.isOwner,
+    // Necessary in v11, can be removed in v12
+    async: true,
+    // Data to fill in for inline rolls
+    rollData: doc.getRollData(),
+    // Relative UUID resolution
+    relativeTo: doc,
+  });
+}
+
+/**
+ * Map shortchallenge Items to plain render objects for challenge-partial.hbs:
+ * `id`/`name`/`system` for the edit branch, plus enriched
+ * `shortDescriptionHTML`/`listHTML` for the view branch.
+ *
+ * @param {Item[]} challenges shortchallenge items
+ * @param {foundry.abstract.Document} doc the actor the enrichment is relative to
+ * @returns {Promise<object[]>}
+ */
+export async function enrichShortChallenges(challenges, doc) {
+  return Promise.all(challenges.map(async (challenge) => ({
+    id: challenge.id,
+    name: challenge.name,
+    system: challenge.system,
+    shortDescriptionHTML: await enrichTextWithTags(challenge.system.shortDescription, doc),
+    listHTML: await Promise.all((challenge.system.list ?? []).map((entry) => enrichTextWithTags(entry, doc))),
+  })));
+}
+
+/**
  * Parse and convert token markup into a styled HTML mark element
  *
  * @param {String} token the token to convert

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -14,6 +14,17 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
     #dragDrop // Private field to hold dragDrop handlers
     #scrollPositions; // Store scroll positions to prevent jumping
 
+    /**
+     * Last known text selection in a UUID-droppable field, as
+     * `{ field, start, end }`. Kept because the field blurs (and its selection
+     * collapses) the moment a drag starts in the sidebar, so at drop time the
+     * live selection is already gone. Updated on every selection change while
+     * the field is focused; consumed by #dropUuidLinkOnField. A re-render
+     * replaces the field elements, which invalidates the cache via its
+     * `field` identity check.
+     */
+    #lastFieldSelection = null;
+
     /** @inheritDoc */
     static DEFAULT_OPTIONS = {
         classes: ['sheet', 'actor'],
@@ -156,6 +167,17 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
     /** @inheritDoc */
     _onRender(context, options) {
         this.#dragDrop.forEach((d) => d.bind(this.element))
+
+        // Track selections in UUID-droppable fields so an actor dragged from
+        // the sidebar (which blurs the field) can still use the selection as
+        // the link label (see #lastFieldSelection).
+        for (const field of this.element.querySelectorAll("input, textarea")) {
+            if (!this._getUuidDroppableField(field)) continue;
+            // `selectionchange` (Chromium 111+) also fires when the selection
+            // collapses; `select` is kept as a fallback for older embedders.
+            field.addEventListener("selectionchange", () => this.#cacheFieldSelection(field));
+            field.addEventListener("select", () => this.#cacheFieldSelection(field));
+        }
 
         if (this.actor.type === "litm-character" || this.actor.type === "litm-npc" || this.actor.type === "litm-journey") {
             this._renderModeToggle();
@@ -685,11 +707,118 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
 
     /**
      * Callback actions which occur when a dragged element is over a drop target.
+     * Marks the UUID-droppable text fields as generic drop targets: this
+     * suppresses the browser's native text-drop handling during the drag (the
+     * moving insertion caret), which would otherwise disturb the field's text
+     * selection before #dropUuidLinkOnField can read it as the link label.
      * @param {DragEvent} event       The originating DragEvent
      * @protected
      */
-    _onDragOver(event) { }
+    _onDragOver(event) {
+        if (this._getUuidDroppableField(event.target)) {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "copy";
+        }
+    }
 
+    /**
+     * Resolve the text field a drag event points at, if that field accepts a
+     * dropped Actor as a `@UUID[...]{Label}` link — i.e. its content is
+     * enriched in view mode via enrichTextWithTags (issue #73). The base
+     * implementation covers the fields of the shared challenge-partial.hbs;
+     * subclasses extend it with their own enriched fields.
+     * @param {EventTarget} target
+     * @returns {HTMLInputElement|HTMLTextAreaElement|null}
+     * @protected
+     */
+    _getUuidDroppableField(target) {
+        if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement)) return null;
+        if (target.classList.contains("editable-challenge-item") && target.dataset.itemId && target.dataset.key === "system.shortDescription") return target;
+        if (target.classList.contains("editable-challenge-item-list-entry") && target.dataset.itemId) return target;
+        return null;
+    }
+
+    /**
+     * Persist `value` as the new raw text of a UUID-droppable field, mirroring
+     * the field's change handler. The base implementation covers the embedded
+     * shortchallenge item fields of challenge-partial.hbs; subclasses handle
+     * their own fields and defer here for the shared ones.
+     * @param {HTMLInputElement|HTMLTextAreaElement} field
+     * @param {string} value
+     * @protected
+     */
+    async _persistUuidDroppedText(field, value) {
+        const item = this.actor.items.get(field.dataset.itemId);
+        if (!item) return;
+        if (field.classList.contains("editable-challenge-item")) {
+            await item.update({ [field.dataset.key]: value });
+        } else if (field.classList.contains("editable-challenge-item-list-entry")) {
+            const index = Number.parseInt(field.dataset.index, 10);
+            const list = item.system.list;
+            if (Number.isNaN(index) || !Array.isArray(list) || index < 0 || index >= list.length) return;
+            list[index] = value;
+            await item.update({ "system.list": list });
+        }
+    }
+
+    /**
+     * Remember `field`'s current selection (collapsed selection clears the
+     * cache). Only honored while the field is focused: the selection collapse
+     * caused by blurring into a sidebar drag also fires `selectionchange`, and
+     * must not clear the cache we need at drop time.
+     */
+    #cacheFieldSelection(field) {
+        if (document.activeElement !== field) return;
+        const start = field.selectionStart ?? 0;
+        const end = field.selectionEnd ?? 0;
+        this.#lastFieldSelection = start !== end ? { field, start, end } : null;
+    }
+
+    /**
+     * Insert a `@UUID[...]{...}` link into the text field the drop landed on
+     * and persist it via _persistUuidDroppedText. If the field has (or had,
+     * before the drag blurred it) a text selection, the selection is replaced
+     * by the link and becomes its label; otherwise the link is appended with
+     * the document's name as label.
+     * @param {DragEvent} event
+     * @param {string} uuid
+     * @returns {Promise<boolean>} true if the drop was consumed by a field.
+     */
+    async #dropUuidLinkOnField(event, uuid) {
+        const field = this._getUuidDroppableField(event.target);
+        if (!field) return false;
+
+        // Without this the browser's default drop pastes the raw drag JSON into the field.
+        event.preventDefault();
+
+        // The drag from the sidebar blurs the field, which collapses its live
+        // selection — fall back to the selection cached while it was focused.
+        let start = field.selectionStart ?? 0;
+        let end = field.selectionEnd ?? 0;
+        if (start === end && this.#lastFieldSelection?.field === field) {
+            end = Math.min(this.#lastFieldSelection.end, field.value.length);
+            start = Math.min(this.#lastFieldSelection.start, end);
+        }
+        this.#lastFieldSelection = null;
+
+        const doc = await fromUuid(uuid);
+        if (!doc) return true;
+
+        let value;
+        if (start !== end) {
+            // `}` would terminate the enricher's label match early; `{` is stripped for symmetry.
+            const label = field.value.slice(start, end).trim().replace(/[{}]/g, "");
+            const link = `@UUID[${uuid}]{${label || doc.name}}`;
+            value = field.value.slice(0, start) + link + field.value.slice(end);
+        } else {
+            const link = `@UUID[${uuid}]{${doc.name}}`;
+            value = field.value.trim() ? `${field.value.trimEnd()} ${link}` : link;
+        }
+
+        this._saveScrollPositions();
+        await this._persistUuidDroppedText(field, value);
+        return true;
+    }
 
     /**
      * Callback actions which occur when a dragged element is dropped on a target.
@@ -698,6 +827,11 @@ export class MistEngineActorSheet extends HandlebarsApplicationMixin(ActorSheetV
      */
     async _onDrop(event) {
         const data = TextEditor.getDragEventData(event);
+
+        // An actor dropped onto an enriched text field becomes a @UUID link (issue #73).
+        if (data.type === "Actor" && data.uuid && (await this.#dropUuidLinkOnField(event, data.uuid))) {
+            return;
+        }
 
         // Handle different data types
         const floatingTagsAndStatuses = this.actor.system.floatingTagsAndStatuses;

--- a/module/sheets/litm-actor-journey-sheet.mjs
+++ b/module/sheets/litm-actor-journey-sheet.mjs
@@ -4,6 +4,8 @@ import { PowerTagAdapter } from '../lib/power-tag-adapter.mjs';
 import { MistSceneApp } from '../apps/scene-app.mjs';
 import { importVignetteForActorJSON } from '../lib/json-importer.mjs';
 import { confirmDeletion } from '../lib/confirm-deletion.mjs';
+import { enrichShortChallenges, enrichTextWithTags } from '../lib/tag-status-text-helper.mjs';
+import { ArrayFieldAdapter } from '../lib/array-field-adapter.mjs';
 
 export class MistEngineLegendInTheMistJourneySheet extends MistEngineActorSheet {
     #dragDrop // Private field to hold dragDrop handlers
@@ -32,7 +34,10 @@ export class MistEngineLegendInTheMistJourneySheet extends MistEngineActorSheet 
         },
         dragDrop: [{
             dragSelector: '[draggable="true"]',
-            dropSelector: '.mist-engine.journey'
+            // Must match the sheet's root classes (mist-engine sheet actor
+            // litm-journey) — the previous '.mist-engine.journey' matched
+            // nothing, so the sheet never received drops at all.
+            dropSelector: '.mist-engine.actor'
         }],
         window: {
             resizable: true,
@@ -100,6 +105,13 @@ export class MistEngineLegendInTheMistJourneySheet extends MistEngineActorSheet 
 
         foundry.utils.mergeObject(context, items);
 
+        // Enrich view-mode text so @UUID[...]{Label} links render as real
+        // content links (issue #73, same treatment as the Challenge sheet).
+        context.generalConsequencesHTML = await Promise.all(
+            (this.document.system.generalConsequences ?? []).map((entry) => enrichTextWithTags(entry, this.document))
+        );
+        context.challenges = await enrichShortChallenges(context.challenges ?? [], this.document);
+
         return context;
     }
 
@@ -152,6 +164,30 @@ export class MistEngineLegendInTheMistJourneySheet extends MistEngineActorSheet 
         for (const input of taggableText) {
             input.addEventListener("keydown", (event) => this.handleInputShortCutsForGM(event));
         }
+    }
+
+    /**
+     * @override The journey's general-consequence inputs (list entries
+     * without a data-item-id), then the shared challenge fields.
+     */
+    _getUuidDroppableField(target) {
+        if (target instanceof HTMLInputElement
+            && target.classList.contains("editable-challenge-item-list-entry")
+            && !target.dataset.itemId) {
+            return target;
+        }
+        return super._getUuidDroppableField(target);
+    }
+
+    /** @override Persist general consequences; shared challenge fields defer to the base. */
+    async _persistUuidDroppedText(field, value) {
+        if (field.classList.contains("editable-challenge-item-list-entry") && !field.dataset.itemId) {
+            const index = Number.parseInt(field.dataset.index, 10);
+            if (Number.isNaN(index)) return;
+            await ArrayFieldAdapter.setIndex(this.actor, "system.generalConsequences", index, value);
+            return;
+        }
+        return super._persistUuidDroppedText(field, value);
     }
 
     async handleChallengeItemUpdate(event) {

--- a/module/sheets/litm-npc-sheet.mjs
+++ b/module/sheets/litm-npc-sheet.mjs
@@ -4,6 +4,7 @@ import { parseChallengeJSON } from '../lib/json-importer.mjs';
 import { ArrayFieldAdapter } from "../lib/array-field-adapter.mjs";
 import { ChallengeAddonAdapter } from "../lib/challenge-addon-adapter.mjs";
 import { confirmDeletion } from "../lib/confirm-deletion.mjs";
+import { enrichShortChallenges, enrichTextWithTags } from "../lib/tag-status-text-helper.mjs";
 
 export class MistEngineLegendInTheMistNpcSheet extends MistEngineActorSheet {
   #dragDrop; // Private field to hold dragDrop handlers
@@ -109,7 +110,51 @@ export class MistEngineLegendInTheMistNpcSheet extends MistEngineActorSheet {
     context.hasSpecialFeatures = this.options.document.system.specialFeatures && this.options.document.system.specialFeatures.length > 0;
     context.hasSecrets = this.options.document.system.secrets && this.options.document.system.secrets.length > 0;
 
+    // Issue #73: enrich consequence/threat text so @UUID[...]{Label} document
+    // links render as real, clickable content links in the view-mode
+    // ("beautified") partial. `context.system` is a plain clone from
+    // toPlainObject() (see actor-sheet.mjs), so extending these arrays with
+    // sibling *HTML fields is safe - it never touches the live document, and
+    // the edit-mode partials (which read the same array by index) keep
+    // reading the untouched raw string fields.
+    context.system.limits = await Promise.all((context.system.limits ?? []).map(async (limit) => ({
+      ...limit,
+      consequenceHTML: await this.#enrichTaggedText(limit.consequence),
+    })));
+
+    context.system.secrets = await Promise.all((context.system.secrets ?? []).map(async (secret) => ({
+      ...secret,
+      descriptionHTML: await this.#enrichTaggedText(secret.description),
+    })));
+
+    context.system.specialFeatures = await Promise.all((context.system.specialFeatures ?? []).map(async (feature) => ({
+      ...feature,
+      nameHTML: await this.#enrichTaggedText(feature.name),
+      descriptionHTML: await this.#enrichTaggedText(feature.description),
+    })));
+
+    context.system.threatsAndConsequences = await Promise.all((context.system.threatsAndConsequences ?? []).map(async (threat) => ({
+      ...threat,
+      descriptionHTML: await this.#enrichTaggedText(threat.description),
+      listHTML: await Promise.all((threat.list ?? []).map((entry) => this.#enrichTaggedText(entry))),
+    })));
+
+    // The challenge templates render through the shared challenge-partial.hbs,
+    // whose view branch expects enriched plain objects.
+    context.challenges = await enrichShortChallenges(context.challenges ?? [], this.document);
+
     return context;
+  }
+
+  /**
+   * Convert a raw consequence/threat string into final display HTML (see
+   * enrichTextWithTags in tag-status-text-helper.mjs for why the tag pass
+   * must run before enrichHTML).
+   * @param {string} raw
+   * @returns {Promise<string>}
+   */
+  async #enrichTaggedText(raw) {
+    return enrichTextWithTags(raw, this.document);
   }
 
   _prepareItems() {
@@ -177,6 +222,19 @@ export class MistEngineLegendInTheMistNpcSheet extends MistEngineActorSheet {
     this.actor.update({ "system.roles": roles });
   }
 
+  /**
+   * The edit-mode text fields whose content is enriched in view mode (see
+   * #enrichTaggedText, issue #73), keyed by data-array with the accepted
+   * data-key values. Only these fields accept a dropped Actor as a
+   * `@UUID[...]{Name}` link — anywhere else a link would never render.
+   */
+  static #UUID_DROPPABLE_FIELDS = {
+    limits: ["consequence"],
+    secrets: ["description"],
+    specialFeatures: ["name", "description"],
+    threatsAndConsequences: ["description"],
+  };
+
   /** @override Apply a dropped Challenge Add-on, otherwise fall back to the base drop handling. */
   async _onDrop(event) {
     const data = foundry.applications.ux.TextEditor.implementation.getDragEventData(event);
@@ -188,6 +246,35 @@ export class MistEngineLegendInTheMistNpcSheet extends MistEngineActorSheet {
       }
     }
     return super._onDrop(event);
+  }
+
+  /** @override The NPC's enriched consequence/threat fields, then the shared challenge fields. */
+  _getUuidDroppableField(target) {
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+      if (target.classList.contains("npc-updatable-threat-entry-stat")) return target;
+      const acceptedKeys = MistEngineLegendInTheMistNpcSheet.#UUID_DROPPABLE_FIELDS[target.dataset.array] ?? [];
+      if (target.classList.contains("npc-updatable-npc-array-stat") && acceptedKeys.includes(target.dataset.key)) {
+        return target;
+      }
+    }
+    return super._getUuidDroppableField(target);
+  }
+
+  /** @override Persist the NPC's array-backed fields; shared challenge fields defer to the base. */
+  async _persistUuidDroppedText(field, value) {
+    const index = Number.parseInt(field.dataset.index, 10);
+    if (field.classList.contains("npc-updatable-threat-entry-stat")) {
+      const listIndex = Number.parseInt(field.dataset.listindex, 10);
+      if (Number.isNaN(index) || Number.isNaN(listIndex)) return;
+      await ArrayFieldAdapter.set(this.actor, "system.threatsAndConsequences", index, `list.${listIndex}`, value);
+      return;
+    }
+    if (field.classList.contains("npc-updatable-npc-array-stat")) {
+      if (Number.isNaN(index)) return;
+      await ArrayFieldAdapter.set(this.actor, `system.${field.dataset.array}`, index, field.dataset.key, value);
+      return;
+    }
+    return super._persistUuidDroppedText(field, value);
   }
 
   static async #handleAddSceneAppRollMod(event, target) {

--- a/templates/actor/parts/challenge-partial.hbs
+++ b/templates/actor/parts/challenge-partial.hbs
@@ -25,14 +25,14 @@
         </fieldset>
     {{else}}
         <h2>{{challenge.name}}</h2>
-        <div class="short-description">{{{textWithTags challenge.system.shortDescription}}}</div>
+        <div class="short-description">{{{challenge.shortDescriptionHTML}}}</div>
         <div class="list-entries">
-            {{#each challenge.system.list as |entry index|}}
+            {{#each challenge.listHTML as |entryHTML index|}}
                 <div class="list-entry">
-                    
+
                     <div class="entry-content-no-edit flexrow">
                         <div class="icon-col"><i class="skull-icon"></i></div>
-                        <div class="text-col">{{{textWithTags entry}}}</div>
+                        <div class="text-col">{{{entryHTML}}}</div>
                     </div>
                 </div>
             {{/each}}

--- a/templates/actor/parts/journey-consequences.hbs
+++ b/templates/actor/parts/journey-consequences.hbs
@@ -33,15 +33,15 @@
     {{else}}
     {{!-- Normal Layout --}}
     <div class="grid grid-2col">
-        {{#if system.generalConsequences}}
+        {{#if generalConsequencesHTML}}
         <div class="challenge-entry-container text-container-large-paper-background">
             <h2>{{localize "MIST_ENGINE.LABELS.GeneralConsequences"}}</h2>
             <div class="list-entries">
-                {{#each system.generalConsequences as | consequence | }}
+                {{#each generalConsequencesHTML as | consequenceHTML | }}
                 <div class="list-entry">
                     <div class="entry-content-no-edit flexrow">
                         <div class="icon-col"><i class="skull-icon"></i></div>
-                        <div class="text-col">{{{textWithTags consequence}}}</div>
+                        <div class="text-col">{{{consequenceHTML}}}</div>
                     </div>
                 </div>
                 {{/each}}

--- a/templates/actor/parts/npc-beautified-partial.hbs
+++ b/templates/actor/parts/npc-beautified-partial.hbs
@@ -13,7 +13,7 @@
                     {{#if limit.reached}}<span class="overcome-badge" title="{{localize 'MIST_ENGINE.OVERCOME.LimitReachedHint'}}">{{localize 'MIST_ENGINE.OVERCOME.Overcome'}}</span>{{/if}}
                 </div>
                 {{#if (notEmpty limit.consequence)}}
-                        <div class="npc-limit-consequence"><i class="icon-round-arrow-up"></i>{{{textWithTags limit.consequence}}}</div>
+                        <div class="npc-limit-consequence"><i class="icon-round-arrow-up"></i>{{{limit.consequenceHTML}}}</div>
                 {{/if}}
                 {{/each}}
             </div>
@@ -50,7 +50,7 @@
                         <img src="systems/mist-engine-fvtt/assets/icons/torch.webp" class="npc-secret-icon">{{secret.name}}
                     </div>
                     <div class="npc-secret-description">
-                        {{{textWithTags secret.description}}}
+                        {{{secret.descriptionHTML}}}
                     </div>
                 </div>
                 {{/each}}
@@ -66,8 +66,8 @@
                 <div class="npc-special-features-list flexcol">
                     {{#each system.specialFeatures as |feature|}}
                     <div class="npc-special-feature-item">
-                        <div class="npc-special-feature-name">{{{textWithTags feature.name}}}</div>
-                        <div class="npc-special-feature-description">{{{textWithTags feature.description}}}</div>
+                        <div class="npc-special-feature-name">{{{feature.nameHTML}}}</div>
+                        <div class="npc-special-feature-description">{{{feature.descriptionHTML}}}</div>
                     </div>
                     {{/each}}
                 </div>
@@ -88,12 +88,12 @@
                         <span class="entry-name">{{threat.name}}</span>
                     {{/if}}
                     {{#if (notEmpty threat.description)}}
-                        <strong>{{{textWithTags threat.description}}}</strong>
+                        <strong>{{{threat.descriptionHTML}}}</strong>
                     {{/if}}
                 </div>
                 <ul class="entry-list">
-                    {{#each threat.list as |entry|}}
-                    <li class="entry-item">{{{textWithTags entry}}}</li>
+                    {{#each threat.listHTML as |html|}}
+                    <li class="entry-item">{{{html}}}</li>
                     {{/each}}
                 </ul>
             </div>

--- a/templates/scene-app/journeys.hbs
+++ b/templates/scene-app/journeys.hbs
@@ -27,15 +27,15 @@
 
         {{!-- Vignettes & Consequences (read-only, like the journey sheet) --}}
         <div class="grid grid-2col">
-            {{#if assignedJourneySystem.generalConsequences.length}}
+            {{#if assignedJourneyGeneralConsequencesHTML.length}}
             <div class="challenge-entry-container text-container-large-paper-background">
                 <h2>{{localize "MIST_ENGINE.LABELS.GeneralConsequences"}}</h2>
                 <div class="list-entries">
-                    {{#each assignedJourneySystem.generalConsequences as | consequence | }}
+                    {{#each assignedJourneyGeneralConsequencesHTML as | consequenceHTML | }}
                     <div class="list-entry">
                         <div class="entry-content-no-edit flexrow">
                             <div class="icon-col"><i class="skull-icon"></i></div>
-                            <div class="text-col">{{{textWithTags consequence}}}</div>
+                            <div class="text-col">{{{consequenceHTML}}}</div>
                         </div>
                     </div>
                     {{/each}}


### PR DESCRIPTION
Fixes #73

Consequence/threat text on the NPC ("Challenge") sheet's view partial now
runs through textWithTags (sync tag-token parser) and then Foundry's
async enrichHTML, so @UUID[...]{Label} document links in limits,
secrets, special features, and threats-and-consequences render as real
clickable content links, while existing [tag]/[/s status] markup in the
same field still styles and drags.
