### PR TITLE
feat: dedicated toolbar control for the Scene App (#91)

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1,5 +1,8 @@
 {
     "MIST_ENGINE": {
+        "CONTROLS": {
+            "GroupTitle": "Mist-Engine-Werkzeuge"
+        },
         "ACTIONS":{
         "ImportChallengeJSON": "Import-Herausforderung von JSON",
         "ImportShortChallengeVignetteJSON": "Import-Kurz-Herausforderung / Vignette von JSON",
@@ -61,7 +64,7 @@
             "WelcomeTitle": "Willkommen, Spielleiter",
             "WelcomeContent": "Diese Tour zeigt dir die Werkzeuge, die das Mist-Engine-System für dich mitbringt. Die meisten findest du hier in den Szenen-Steuerungen auf der linken Seite. Nutze die Pfeiltasten oder die Buttons, um durch die Tour zu blättern.",
             "ToolsTitle": "Deine Spielleiter-Leiste",
-            "ToolsContent": "Unter den Notizen-Steuerungen liegen die Spielleiter-Apps des Systems: Szenen-Tracker, Lager & Aufenthalte, Gemeinsam handeln und How To Play. Wir schauen uns jede an.",
+            "ToolsContent": "Unter den Mist-Engine-Steuerungen liegen die Spielleiter-Apps des Systems: Szenen-Tracker, Lager & Aufenthalte, Gemeinsam handeln und How To Play. Wir schauen uns jede an.",
             "SceneTrackerTitle": "Szenen-Tracker",
             "SceneTrackerContent": "Öffnet die gemeinsamen Story-Tags, Status und Würfel-Modifikatoren der Szene, dazu die anwesenden Charaktere und Herausforderungen. Tags, die du hier setzt, fließen automatisch in die Würfe der Spieler ein. Benötigt eine aktive Szene.",
             "CampingTitle": "Lager & Aufenthalte",
@@ -119,7 +122,11 @@
             "Rotes": "Rotes"
         },
         "SCENE_APP": {
+            "Title": "Szenen-Tags",
             "NoActiveScene": "Der Szenen-Tracker benötigt eine aktive Szene. Aktiviere zuerst eine Szene."
+        },
+        "HOW_TO_PLAY": {
+            "Title": "How To Play"
         },
         "HELP": {
             "BackpackSheet": "Rucksack-Einträge werden direkt auf dem Charakterbogen bearbeitet (Edit-Modus der Rucksack-Karte). Der Description-Tab liefert den Tooltip-Text.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -4,6 +4,9 @@
       "UpdatedTo": "Updated to version",
       "DontShowAgain": "Don't show again for this version"
     },
+    "CONTROLS": {
+      "GroupTitle": "Mist Engine Tools"
+    },
     "PROSEMIRROR": {
       "MarkAsTag": "Mark as Tag",
       "MarkAsStatus": "Mark as Status"
@@ -83,6 +86,7 @@
       }
     },
     "SCENE_APP": {
+      "Title": "Scene Tags",
       "NoActiveScene": "The scene tracker needs an active scene. Activate a scene first.",
       "Weaknesses": "Weaknesses (GM)",
       "WeaknessToggleHint": "Click to toggle this weakness as active in the scene",
@@ -96,6 +100,9 @@
       "RemoveStoryTheme": "Remove story theme",
       "OnlyStoryThemes": "Only themebooks flagged as a Story Theme can be added here.",
       "NoStoryThemes": "No story themes yet. Drag a Story Theme from the sidebar or a compendium onto this app to add it to the scene."
+    },
+    "HOW_TO_PLAY": {
+      "Title": "How To Play"
     },
     "MIGHT": {
       "None": "— None —",
@@ -206,7 +213,7 @@
       "WelcomeTitle": "Welcome, Narrator",
       "WelcomeContent": "This tour shows the tools the Mist Engine system adds for you. Most of them live here in the scene controls on the left. Use the arrow keys or the buttons to move through the tour.",
       "ToolsTitle": "Your GM Toolbar",
-      "ToolsContent": "Under the Notes controls you'll find the system's GM apps: the Scene Tracker, Camping & Sojourns, Acting Together and How To Play. We'll look at each one.",
+      "ToolsContent": "Under the Mist Engine controls you'll find the system's GM apps: the Scene Tracker, Camping & Sojourns, Acting Together and How To Play. We'll look at each one.",
       "SceneTrackerTitle": "Scene Tracker",
       "SceneTrackerContent": "Opens the scene's shared story tags, statuses and dice-roll modifiers, plus the characters and challenges present. Tags you add here flow automatically into the players' rolls. It needs an active scene.",
       "CampingTitle": "Camping & Sojourns",

--- a/lang/es.json
+++ b/lang/es.json
@@ -103,7 +103,7 @@
       "WelcomeTitle": "Bienvenido, Narrador",
       "WelcomeContent": "Esta visita muestra las herramientas que el sistema Mist Engine añade para ti. La mayoría están aquí, en los controles de escena a la izquierda. Usa las flechas o los botones para avanzar por la visita.",
       "ToolsTitle": "Tu barra de DJ",
-      "ToolsContent": "Bajo los controles de Notas encontrarás las apps de DJ del sistema: el Rastreador de Escena, Acampada y Estancias, Actuar en Grupo y How To Play. Veremos cada una.",
+      "ToolsContent": "Bajo los controles de Mist Engine encontrarás las apps de DJ del sistema: el Rastreador de Escena, Acampada y Estancias, Actuar en Grupo y How To Play. Veremos cada una.",
       "SceneTrackerTitle": "Rastreador de Escena",
       "SceneTrackerContent": "Abre las etiquetas de historia, estados y modificadores de tirada compartidos de la escena, además de los personajes y desafíos presentes. Las etiquetas que añadas aquí entran automáticamente en las tiradas de los jugadores. Necesita una escena activa.",
       "CampingTitle": "Acampada y Estancias",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -96,7 +96,7 @@
       "WelcomeTitle": "Bienvenue, Narrateur",
       "WelcomeContent": "Cette visite présente les outils que le système Mist Engine ajoute pour vous. La plupart se trouvent ici, dans les contrôles de scène à gauche. Utilisez les flèches ou les boutons pour parcourir la visite.",
       "ToolsTitle": "Votre barre de MJ",
-      "ToolsContent": "Sous les contrôles Notes se trouvent les applis MJ du système : le Suivi de Scène, Campement et Séjours, Agir Ensemble et How To Play. Nous allons voir chacune.",
+      "ToolsContent": "Sous les contrôles Mist Engine se trouvent les applis MJ du système : le Suivi de Scène, Campement et Séjours, Agir Ensemble et How To Play. Nous allons voir chacune.",
       "SceneTrackerTitle": "Suivi de Scène",
       "SceneTrackerContent": "Ouvre les étiquettes d'histoire, statuts et modificateurs de jet partagés de la scène, ainsi que les personnages et défis présents. Les étiquettes que vous ajoutez ici entrent automatiquement dans les jets des joueurs. Nécessite une scène active.",
       "CampingTitle": "Campement et Séjours",

--- a/module/lib/gm-tour.mjs
+++ b/module/lib/gm-tour.mjs
@@ -3,10 +3,11 @@
  *
  * Registered under `game.tours` so it appears in Tour Management, and
  * auto-started once for a GM who has not seen it yet. `canStart` gates it to
- * GMs; `_preStep` activates the scene-controls Notes tools and opens a demo
- * character sheet so the highlighted selectors resolve. Intentionally has NO
- * imports on other app modules so it always loads regardless of which optional
- * features a build ships — the demo actor is fetched via core APIs only.
+ * GMs; `_preStep` activates the scene-controls "Mist Engine" tool group and
+ * opens a demo character sheet so the highlighted selectors resolve.
+ * Intentionally has NO imports on other app modules so it always loads
+ * regardless of which optional features a build ships — the demo actor is
+ * fetched via core APIs only.
  */
 const SEEN_SETTING = "gmTutorialSeen";
 const t = (k) => `MIST_ENGINE.TUTORIAL.${k}`;
@@ -23,11 +24,11 @@ const DEMO_ACTOR_NAME = "Finn The Red Marshal";
  * edit/game mode before the step.
  */
 const STEPS = [
-    { id: "welcome", selector: "#scene-controls", title: t("WelcomeTitle"), content: t("WelcomeContent"), activateNotes: true },
-    { id: "tools", selector: "#scene-controls-tools", title: t("ToolsTitle"), content: t("ToolsContent"), activateNotes: true },
-    { id: "sceneTracker", selector: toolSelector("scene_data_app"), title: t("SceneTrackerTitle"), content: t("SceneTrackerContent"), activateNotes: true },
-    { id: "camping", selector: toolSelector("camping_app"), title: t("CampingTitle"), content: t("CampingContent"), activateNotes: true },
-    { id: "groupAction", selector: toolSelector("group_action_app"), title: t("GroupActionTitle"), content: t("GroupActionContent"), activateNotes: true },
+    { id: "welcome", selector: "#scene-controls", title: t("WelcomeTitle"), content: t("WelcomeContent"), activateControl: "mist-engine" },
+    { id: "tools", selector: "#scene-controls-tools", title: t("ToolsTitle"), content: t("ToolsContent"), activateControl: "mist-engine" },
+    { id: "sceneTracker", selector: toolSelector("scene_data_app"), title: t("SceneTrackerTitle"), content: t("SceneTrackerContent"), activateControl: "mist-engine" },
+    { id: "camping", selector: toolSelector("camping_app"), title: t("CampingTitle"), content: t("CampingContent"), activateControl: "mist-engine" },
+    { id: "groupAction", selector: toolSelector("group_action_app"), title: t("GroupActionTitle"), content: t("GroupActionContent"), activateControl: "mist-engine" },
 
     // --- player character walkthrough (demo actor: Finn) ---
     { id: "charSheet", within: ".sheet-header", title: t("CharSheetTitle"), content: t("CharSheetContent"), charMode: "game" },
@@ -37,7 +38,7 @@ const STEPS = [
 
     { id: "challenges", selector: "#sidebar", title: t("ChallengesTitle"), content: t("ChallengesContent") },
     { id: "rollConfirm", selector: "#sidebar", title: t("RollConfirmTitle"), content: t("RollConfirmContent") },
-    { id: "howToPlay", selector: toolSelector("how_to_play_app"), title: t("HowToPlayTitle"), content: t("HowToPlayContent"), activateNotes: true },
+    { id: "howToPlay", selector: toolSelector("how_to_play_app"), title: t("HowToPlayTitle"), content: t("HowToPlayContent"), activateControl: "mist-engine" },
 ];
 
 export function registerGmTour() {
@@ -84,8 +85,8 @@ export function registerGmTour() {
             const step = this.currentStep;
             if (!step) return;
 
-            if (step.activateNotes) {
-                try { ui.controls?.activate({ control: "notes" }); } catch (e) { /* no canvas */ }
+            if (step.activateControl) {
+                try { ui.controls?.activate({ control: step.activateControl }); } catch (e) { /* no canvas */ }
                 await new Promise(r => setTimeout(r, 250));
             }
 

--- a/module/lib/hooks.mjs
+++ b/module/lib/hooks.mjs
@@ -309,46 +309,61 @@ export function setupHooks() {
     img.classList.remove("fa-spin");
   });
 
+  // Dedicated top-level toolbar group for the system's own apps (issue #91):
+  // previously these were merged into the core Notes toolbox, which buried
+  // the Scene App (and the other Mist apps) behind an unrelated tool group.
+  // This control has no `layer` and no `onChange`, and every tool is a
+  // `button: true` "fire and forget" opener rather than a selectable tool —
+  // per core's SceneControls#activate (client/applications/ui/scene-
+  // controls.mjs), a control only touches the canvas via its own onChange
+  // calling `canvas.<layer>.activate()`; without one, clicking this group
+  // only changes which tool tray is displayed and leaves whichever canvas
+  // layer (e.g. Token Controls) was active untouched and still interactive.
   Hooks.on("getSceneControlButtons", (controls) => {
-    let sidebarControls = {
-      scene_data_app: {
-        name: "scene_data_app",
-        title: "Scene Tags",
-        icon: "fas fa-scroll",
-        visible: true,
-        onChange: () => MistSceneApp.open(),
-        button: true,
-      },
-      camping_app: {
-        name: "camping_app",
-        title: game.i18n.localize("MIST_ENGINE.CAMPING.Title"),
-        icon: "fas fa-campground",
-        visible: game.user.isGM,
-        onChange: () => CampingApp.openForGM(),
-        button: true,
-      },
-      group_action_app: {
-        name: "group_action_app",
-        title: game.i18n.localize("MIST_ENGINE.COLLAB.GroupTitle"),
-        icon: "fas fa-people-group",
-        visible: game.user.isGM,
-        onChange: () => Collaboration.openGroupAction(),
-        button: true,
-      },
-      how_to_play_app: {
-        name: "how_to_play_app",
-        title: "How To Play",
-        icon: "fas fa-circle-question",
-        visible: true,
-        onChange: () => HowToPlayApp.getInstance().render(true, { focus: true }),
-        button: true,
+    controls["mist-engine"] = {
+      name: "mist-engine",
+      title: game.i18n.localize("MIST_ENGINE.CONTROLS.GroupTitle"),
+      icon: "fas fa-smog",
+      order: 11, // after all core control groups (Notes is order 8 on v14 but 10 on v13, with Regions at 9)
+      tools: {
+        scene_data_app: {
+          name: "scene_data_app",
+          order: 1,
+          title: game.i18n.localize("MIST_ENGINE.SCENE_APP.Title"),
+          icon: "fas fa-scroll",
+          visible: true,
+          onChange: () => MistSceneApp.open(),
+          button: true,
+        },
+        camping_app: {
+          name: "camping_app",
+          order: 2,
+          title: game.i18n.localize("MIST_ENGINE.CAMPING.Title"),
+          icon: "fas fa-campground",
+          visible: game.user.isGM,
+          onChange: () => CampingApp.openForGM(),
+          button: true,
+        },
+        group_action_app: {
+          name: "group_action_app",
+          order: 3,
+          title: game.i18n.localize("MIST_ENGINE.COLLAB.GroupTitle"),
+          icon: "fas fa-people-group",
+          visible: game.user.isGM,
+          onChange: () => Collaboration.openGroupAction(),
+          button: true,
+        },
+        how_to_play_app: {
+          name: "how_to_play_app",
+          order: 4,
+          title: game.i18n.localize("MIST_ENGINE.HOW_TO_PLAY.Title"),
+          icon: "fas fa-circle-question",
+          visible: true,
+          onChange: () => HowToPlayApp.getInstance().render(true, { focus: true }),
+          button: true,
+        },
       },
     };
-
-    controls.notes.tools = foundry.utils.mergeObject(
-      controls.notes.tools,
-      sidebarControls
-    );
   });
 
   Hooks.on("renderItemDirectory", (_app, html) => {

--- a/module/lib/player-tour.mjs
+++ b/module/lib/player-tour.mjs
@@ -40,7 +40,7 @@ const STEPS = [
     { id: "fellowship", within: ".litm-fellowship-relationship", title: t("FellowshipTitle"), content: t("FellowshipContent"), charMode: "game" },
     { id: "otherTab", within: '.litm-character-sheet-tabs [data-tab="other"]', title: t("OtherTabTitle"), content: t("OtherTabContent"), charMode: "game" },
     { id: "bioNotes", within: '.litm-character-sheet-tabs [data-tab="biography"]', title: t("BioNotesTitle"), content: t("BioNotesContent"), charMode: "game" },
-    { id: "howToPlay", selector: toolSelector("how_to_play_app"), title: t("HowToPlayTitle"), content: t("HowToPlayContent"), activateNotes: true },
+    { id: "howToPlay", selector: toolSelector("how_to_play_app"), title: t("HowToPlayTitle"), content: t("HowToPlayContent"), activateControl: "mist-engine" },
 ];
 
 export function registerPlayerTour() {
@@ -95,8 +95,8 @@ export function registerPlayerTour() {
             // as soon as the tour moves on so it never covers a sheet step.
             if (!step.openRollDialog) this.#closeRollDialog();
 
-            if (step.activateNotes) {
-                try { ui.controls?.activate({ control: "notes" }); } catch (e) { /* no canvas */ }
+            if (step.activateControl) {
+                try { ui.controls?.activate({ control: step.activateControl }); } catch (e) { /* no canvas */ }
                 await new Promise(r => setTimeout(r, 250));
             }
 


### PR DESCRIPTION
This touches on something mentioned in #91

I am not sure about the icon used, and also see the original issue has been self-assigned. Leaving this up as a suggestion for solving access as I also thought it weird to leave it in the journal notes thing (although it makes sense, and I have done it myself in the original demo)

The Scene App was buried as a tool inside the core Notes control group
alongside three other unrelated system apps (Camping & Sojourns, Acting
Together, How To Play). All four now live in their own top-level "Mist
Engine" toolbar control, so the Scene App is one click away instead of
hidden in an unrelated toolbox. Both guided tours and the affected
localized strings (en/de + stale copy in fr/es) were updated to match.
