### PR TITLE
feat: setting to choose theme-kit source compendiums (#101)

### DIFF
--- a/css/mist-engine-fvtt.css
+++ b/css/mist-engine-fvtt.css
@@ -4691,6 +4691,80 @@ article.cc-enriched section.journal-entry-content {
   line-height: 1.5em;
 }
 
+#themekit-source-settings-app > section.window-content {
+  background-image: url("../assets/bg-dark-old-paper-textures.webp");
+  background-repeat: no-repeat;
+  font-family: Labrada, serif;
+  color: var(--litm-color-accent);
+}
+#themekit-source-settings-app > section.window-content .themekit-source-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+#themekit-source-settings-app > section.window-content .themekit-source-settings .hint {
+  font-size: 0.9em;
+  font-style: italic;
+  opacity: 0.8;
+  margin: 0;
+}
+#themekit-source-settings-app > section.window-content .themekit-source-settings .themekit-source-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 50vh;
+  overflow-y: auto;
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 5px;
+  padding: 8px;
+}
+#themekit-source-settings-app > section.window-content .themekit-source-settings .themekit-source-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+#themekit-source-settings-app > section.window-content .themekit-source-settings .themekit-source-group .group-header {
+  font-size: 0.8em;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.7;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  margin: 0 0 4px;
+  padding-bottom: 2px;
+}
+#themekit-source-settings-app > section.window-content .themekit-source-settings .themekit-source-entry {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 4px;
+  border-radius: 3px;
+  cursor: pointer;
+}
+#themekit-source-settings-app > section.window-content .themekit-source-settings .themekit-source-entry:hover {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+#themekit-source-settings-app > section.window-content .themekit-source-settings .themekit-source-entry input[type=checkbox] {
+  accent-color: var(--litm-color-accent);
+  cursor: pointer;
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  margin: 0;
+}
+#themekit-source-settings-app > section.window-content .themekit-source-settings .empty-message {
+  font-style: italic;
+  opacity: 0.7;
+  text-align: center;
+  margin: 0;
+}
+#themekit-source-settings-app > section.window-content .themekit-source-settings .dialog-footer {
+  display: flex;
+}
+#themekit-source-settings-app > section.window-content .themekit-source-settings .dialog-footer .roll-button {
+  flex: 1;
+}
+
 #themekit-character-app > section.window-content {
   background-image: url("../assets/bg-dark-old-paper-textures.webp");
   background-repeat: no-repeat;

--- a/lang/de.json
+++ b/lang/de.json
@@ -297,6 +297,20 @@
                 "SpecialFeatures": "Spezialmerkmale",
                 "ThreatsAndConsequences": "Bedrohungen & Konsequenzen"
             }
+        },
+        "SETTINGS": {
+            "ThemekitSourcePacks": {
+                "MenuName": "Theme-Kit-Quellkompendien",
+                "MenuLabel": "Quellen konfigurieren",
+                "MenuHint": "Wähle, welche Kompendien — und ob Gegenstände in der Welt — Themekits für die Themekit-Auswahl liefern dürfen.",
+                "WindowTitle": "Theme-Kit-Quellen",
+                "Explanation": "Kreuze die Kompendien an, die Themekits liefern sollen. Wenn du keins ankreuzt — oder alle ankreuzt — sind alle Kompendien erlaubt, auch später installierte (Standardverhalten). Die Weltgegenstände-Checkbox darüber ist unabhängig: Sie schaltet nur um, ob Gegenstände dieser Welt angeboten werden.",
+                "WorldSource": "Welt-Kompendium",
+                "WorldItemsGroup": "Diese Welt",
+                "WorldItemsEntry": "Gegenstände in der Welt (Items-Verzeichnis)",
+                "NoPacksAvailable": "Keine Item-Kompendien gefunden.",
+                "Save": "Speichern"
+            }
         }
     },
      "TYPES": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -27,6 +27,20 @@
       "AssignThemekit": "Assign Themekit",
       "NoThemekitsAvailable": "No themekits available. Create themekit items first."
     },
+    "SETTINGS": {
+      "ThemekitSourcePacks": {
+        "MenuName": "Theme-Kit Source Compendiums",
+        "MenuLabel": "Configure Sources",
+        "MenuHint": "Choose which compendiums — and whether items in the world — may supply themekits in the Themekit selector.",
+        "WindowTitle": "Theme-Kit Sources",
+        "Explanation": "Check the compendiums that should provide themekits in the selector. Leaving none checked — or checking all of them — allows every compendium, including any installed later (default behavior). The world-items checkbox above is independent: it simply toggles whether items in this world are offered.",
+        "WorldSource": "World Compendium",
+        "WorldItemsGroup": "This World",
+        "WorldItemsEntry": "Items in the world (Items directory)",
+        "NoPacksAvailable": "No Item compendiums were found.",
+        "Save": "Save"
+      }
+    },
     "QUESTIONS": {
       "ConfirmDeletionTitle": "Confirm Deletion",
       "ConfirmDeletion": "Are you sure you want to delete this?",

--- a/module/apps/themekit-selection-app.mjs
+++ b/module/apps/themekit-selection-app.mjs
@@ -72,15 +72,30 @@ export class ThemekitSelectionApp extends HandlebarsApplicationMixin(Application
     }
 
     async getAllThemekits(){
-       // Welt: only themekits the current user is allowed to see
-        const worldThemeKits = game.items.filter(i => i.type === "themekit" && i.visible);
+        // Welt: only themekits the current user is allowed to see, and only
+        // if the GM hasn't disabled world items as a themekit source. The
+        // `!== false` guard keeps world items included if the stored value
+        // is ever malformed (preserves pre-toggle behavior).
+        const includeWorldItems = game.settings.get("mist-engine-fvtt", "themekitIncludeWorldItems") !== false;
+        const worldThemeKits = includeWorldItems
+            ? game.items.filter(i => i.type === "themekit" && i.visible)
+            : [];
 
         // Kompendien: skip packs hidden from the current user
         const compendiumThemeKits = [];
 
+        // Issue #101: GM-configured allowlist of pack collection ids. An
+        // empty/unset array means no restriction (preserves prior behavior,
+        // scanning every visible Item pack); a non-empty array restricts
+        // scanning to just those packs. World items are governed by the
+        // separate themekitIncludeWorldItems toggle above, not this list.
+        const allowedSourcePacks = game.settings.get("mist-engine-fvtt", "themekitSourcePacks");
+        const hasSourceAllowlist = Array.isArray(allowedSourcePacks) && allowedSourcePacks.length > 0;
+
         for (const pack of game.packs) {
             if (pack.documentName !== "Item") continue;
             if (!pack.visible) continue;
+            if (hasSourceAllowlist && !allowedSourcePacks.includes(pack.collection)) continue;
 
             const docs = await pack.getDocuments();
             compendiumThemeKits.push(

--- a/module/apps/themekit-source-settings-app.mjs
+++ b/module/apps/themekit-source-settings-app.mjs
@@ -1,0 +1,109 @@
+const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
+
+const SYSTEM_ID = "mist-engine-fvtt";
+const SETTING_KEY = "themekitSourcePacks";
+const WORLD_ITEMS_SETTING_KEY = "themekitIncludeWorldItems";
+
+/**
+ * GM-only settings menu (issue #101) letting the GM restrict which visible
+ * Item compendiums may supply themekits in the ThemekitSelectionApp.
+ *
+ * Persists an array of `pack.collection` ids to the world setting
+ * `themekitSourcePacks`. An empty array means "no restriction" — every
+ * visible Item compendium is allowed, which is also the default and
+ * preserves pre-#101 behavior. Whether world items (not in any compendium)
+ * are included is governed by the separate boolean setting
+ * `themekitIncludeWorldItems`, edited here as the "This World" checkbox.
+ */
+export class ThemekitSourceSettingsApp extends HandlebarsApplicationMixin(ApplicationV2) {
+
+    /** @inheritDoc */
+    static DEFAULT_OPTIONS = {
+        id: 'themekit-source-settings-app',
+        classes: ['mist-engine', 'dialog', 'themekit-source-settings-app'],
+        tag: 'div',
+        window: {
+            frame: true,
+            title: 'MIST_ENGINE.SETTINGS.ThemekitSourcePacks.WindowTitle',
+            icon: 'fa-solid fa-book-atlas',
+            positioned: true,
+            resizable: true
+        },
+        position: {
+            width: 500,
+            height: 'auto'
+        },
+        actions: {
+            saveThemekitSources: this.#handleSave
+        },
+    };
+
+    /** @override */
+    static PARTS = {
+        form: {
+            template: 'systems/mist-engine-fvtt/templates/themekit-source-settings-app/form.hbs',
+            scrollable: ['.themekit-source-list']
+        }
+    };
+
+    async _prepareContext(options) {
+        const context = await super._prepareContext(options);
+        const allowed = ThemekitSourceSettingsApp.#getAllowedCollections();
+
+        // Empty allowlist means "all allowed" — every pack starts checked in
+        // that case, matching the current (pre-setting) unfiltered behavior.
+        const packs = game.packs
+            .filter(pack => pack.documentName === "Item")
+            .map(pack => ({
+                collection: pack.collection,
+                title: pack.title,
+                source: pack.metadata.packageType === "world"
+                    ? game.i18n.localize("MIST_ENGINE.SETTINGS.ThemekitSourcePacks.WorldSource")
+                    : (pack.metadata.packageName ?? pack.metadata.packageType),
+                allowed: allowed.length === 0 || allowed.includes(pack.collection)
+            }))
+            .sort((a, b) => a.title.localeCompare(b.title));
+
+        const groups = new Map();
+        for (const pack of packs) {
+            if (!groups.has(pack.source)) groups.set(pack.source, { source: pack.source, packs: [] });
+            groups.get(pack.source).packs.push(pack);
+        }
+
+        context.groups = Array.from(groups.values())
+            .sort((a, b) => a.source.localeCompare(b.source));
+        context.hasPacks = packs.length > 0;
+        context.includeWorldItems = game.settings.get(SYSTEM_ID, WORLD_ITEMS_SETTING_KEY) !== false;
+        return context;
+    }
+
+    static #getAllowedCollections() {
+        const stored = game.settings.get(SYSTEM_ID, SETTING_KEY);
+        return Array.isArray(stored) ? stored : [];
+    }
+
+    static async #handleSave(event, target) {
+        event.preventDefault();
+        // Pack checkboxes only — the world-items checkbox (data-world-items)
+        // is a separate boolean setting and must not participate in the
+        // "all checked → []" normalization below.
+        const allCheckboxes = Array.from(
+            this.element.querySelectorAll('.themekit-source-list input[type="checkbox"]:not([data-world-items])')
+        );
+        const checked = allCheckboxes.filter(cb => cb.checked).map(cb => cb.value);
+
+        // Every currently-listed pack checked is functionally identical to
+        // none checked (both mean "no restriction" today), but they are NOT
+        // identical for the future: storing the full id list would freeze
+        // the allowlist to today's packs and silently exclude any
+        // compendium installed later, whereas [] keeps meaning "allow
+        // everything, including packs that don't exist yet". So normalize
+        // "all checked" down to [] rather than storing the literal list.
+        const allChecked = allCheckboxes.length > 0 && checked.length === allCheckboxes.length;
+        await game.settings.set(SYSTEM_ID, SETTING_KEY, allChecked ? [] : checked);
+
+        const worldItemsCheckbox = this.element.querySelector('.themekit-source-list input[data-world-items]');
+        await game.settings.set(SYSTEM_ID, WORLD_ITEMS_SETTING_KEY, worldItemsCheckbox?.checked ?? true);
+        this.close();
+    }
+}

--- a/module/lib/configuration.mjs
+++ b/module/lib/configuration.mjs
@@ -1,3 +1,5 @@
+import { ThemekitSourceSettingsApp } from "../apps/themekit-source-settings-app.mjs";
+
 export function setupConfiguration() {
 
     game.settings.register("mist-engine-fvtt", "systemVersion", {
@@ -62,6 +64,38 @@ export function setupConfiguration() {
         config: true,
         type: Boolean,
         default: false
-    });    
+    });
+
+    // Issue #101: allowlist of compendium pack collection ids that may
+    // supply themekits in ThemekitSelectionApp#getAllThemekits(). Hidden
+    // (config: false) since it's edited through the registerMenu below;
+    // an empty array means "no restriction" (every visible Item pack is
+    // allowed), which is also the default and preserves prior behavior.
+    game.settings.register("mist-engine-fvtt", "themekitSourcePacks", {
+        scope: "world",
+        config: false,
+        type: Array,
+        default: []
+    });
+
+    // Companion toggle to themekitSourcePacks: whether themekits from
+    // in-world items (game.items) are offered in ThemekitSelectionApp.
+    // Hidden (config: false) — edited through the same menu below.
+    // Default true preserves prior behavior (world items always included).
+    game.settings.register("mist-engine-fvtt", "themekitIncludeWorldItems", {
+        scope: "world",
+        config: false,
+        type: Boolean,
+        default: true
+    });
+
+    game.settings.registerMenu("mist-engine-fvtt", "themekitSourcePacksMenu", {
+        name: "MIST_ENGINE.SETTINGS.ThemekitSourcePacks.MenuName",
+        label: "MIST_ENGINE.SETTINGS.ThemekitSourcePacks.MenuLabel",
+        hint: "MIST_ENGINE.SETTINGS.ThemekitSourcePacks.MenuHint",
+        icon: "fa-solid fa-book-atlas",
+        type: ThemekitSourceSettingsApp,
+        restricted: true
+    });
 
 }

--- a/src/scss/components/_themekit_source_settings_app.scss
+++ b/src/scss/components/_themekit_source_settings_app.scss
@@ -1,0 +1,84 @@
+#themekit-source-settings-app>section.window-content {
+    background-image: url("../assets/bg-dark-old-paper-textures.webp");
+    background-repeat: no-repeat;
+    font-family: $font-primary;
+    color: var(--litm-color-accent);
+
+    .themekit-source-settings {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+
+        .hint {
+            font-size: 0.9em;
+            font-style: italic;
+            opacity: 0.8;
+            margin: 0;
+        }
+
+        .themekit-source-list {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            max-height: 50vh;
+            overflow-y: auto;
+            background-color: rgba(0, 0, 0, 0.1);
+            border-radius: 5px;
+            padding: 8px;
+        }
+
+        .themekit-source-group {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+
+            .group-header {
+                font-size: 0.8em;
+                font-weight: bold;
+                text-transform: uppercase;
+                letter-spacing: 0.05em;
+                opacity: 0.7;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+                margin: 0 0 4px;
+                padding-bottom: 2px;
+            }
+        }
+
+        .themekit-source-entry {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 2px 4px;
+            border-radius: 3px;
+            cursor: pointer;
+
+            &:hover {
+                background-color: rgba(0, 0, 0, 0.2);
+            }
+
+            input[type="checkbox"] {
+                accent-color: var(--litm-color-accent);
+                cursor: pointer;
+                width: 13px;
+                height: 13px;
+                flex-shrink: 0;
+                margin: 0;
+            }
+        }
+
+        .empty-message {
+            font-style: italic;
+            opacity: 0.7;
+            text-align: center;
+            margin: 0;
+        }
+
+        .dialog-footer {
+            display: flex;
+
+            .roll-button {
+                flex: 1;
+            }
+        }
+    }
+}

--- a/src/scss/mist-engine-fvtt.scss
+++ b/src/scss/mist-engine-fvtt.scss
@@ -51,6 +51,7 @@
 @import "components/group_action_app";
 @import "components/character_overlay";
 @import "components/themekit_selection_app";
+@import "components/themekit_source_settings_app";
 @import "components/themekit_character_app";
 @import "components/how_to_play_app";
 @import "components/changelog_app";

--- a/templates/themekit-source-settings-app/form.hbs
+++ b/templates/themekit-source-settings-app/form.hbs
@@ -1,0 +1,35 @@
+<div class="themekit-source-settings">
+    <p class="hint">{{localize "MIST_ENGINE.SETTINGS.ThemekitSourcePacks.Explanation"}}</p>
+
+    <div class="themekit-source-list">
+        <div class="themekit-source-group">
+            <h3 class="group-header">{{localize "MIST_ENGINE.SETTINGS.ThemekitSourcePacks.WorldItemsGroup"}}</h3>
+            <label class="themekit-source-entry">
+                <input type="checkbox" data-world-items {{#if includeWorldItems}}checked{{/if}}>
+                <span class="themekit-source-title">{{localize "MIST_ENGINE.SETTINGS.ThemekitSourcePacks.WorldItemsEntry"}}</span>
+            </label>
+        </div>
+
+        {{#each groups}}
+        <div class="themekit-source-group">
+            <h3 class="group-header">{{this.source}}</h3>
+            {{#each this.packs}}
+            <label class="themekit-source-entry">
+                <input type="checkbox" value="{{this.collection}}" {{#if this.allowed}}checked{{/if}}>
+                <span class="themekit-source-title">{{this.title}}</span>
+            </label>
+            {{/each}}
+        </div>
+        {{/each}}
+
+        {{#unless hasPacks}}
+        <p class="empty-message">{{localize "MIST_ENGINE.SETTINGS.ThemekitSourcePacks.NoPacksAvailable"}}</p>
+        {{/unless}}
+    </div>
+
+    <footer class="dialog-footer">
+        <button type="button" class="roll-button" data-action="saveThemekitSources">
+            <i class="fa-solid fa-floppy-disk"></i> {{localize "MIST_ENGINE.SETTINGS.ThemekitSourcePacks.Save"}}
+        </button>
+    </footer>
+</div>


### PR DESCRIPTION
Fixes #101

Adds a GM-only world setting (via a settings submenu) listing which
visible Item compendiums may supply themekits in the Themekit
selector. Leaving all sources unchecked (the default) preserves prior
behavior — every visible Item compendium is scanned. World items are
always included regardless of the setting.
