### PR TITLE
Feature/scene tags overlay - organize by story theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .DS_Store
 .AppleDouble
 .LSOverride
+FEATURE-REQUESTS-FROM-ADDON.md

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@
 .DS_Store
 .AppleDouble
 .LSOverride
-FEATURE-REQUESTS-FROM-ADDON.md

--- a/css/mist-engine-fvtt.css
+++ b/css/mist-engine-fvtt.css
@@ -4753,6 +4753,33 @@ article.cc-enriched section.journal-entry-content {
   min-width: 0;
 }
 
+.litm-sto-theme-groups {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px 12px;
+  min-width: 0;
+}
+
+.litm-sto-theme-group {
+  display: flex;
+  flex: 0 1 auto;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: center;
+  gap: 4px 7px;
+  min-width: 0;
+}
+
+.litm-sto-theme-name {
+  color: rgba(239, 214, 147, 0.88);
+  font-family: var(--litm-font-heading);
+  font-size: 0.72rem;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
 .litm-sto-tag {
   padding: 1px 8px;
   border-radius: 3px 2px 3px 2px;

--- a/css/mist-engine-fvtt.css
+++ b/css/mist-engine-fvtt.css
@@ -4756,15 +4756,15 @@ article.cc-enriched section.journal-entry-content {
 .litm-sto-theme-groups {
   display: flex;
   flex: 1 1 auto;
-  flex-wrap: wrap;
+  flex-direction: column;
   justify-content: center;
-  gap: 6px 12px;
+  gap: 6px;
   min-width: 0;
 }
 
 .litm-sto-theme-group {
   display: flex;
-  flex: 0 1 auto;
+  width: 100%;
   flex-wrap: wrap;
   align-items: baseline;
   justify-content: center;

--- a/lang/de.json
+++ b/lang/de.json
@@ -337,7 +337,8 @@
       "SceneCaption": "Szene",
       "SceneTagsLabel": "Szenen-Tags & Statuses",
       "SelectedHint": "Von der Erzählerin ausgewählt",
-      "StoryCaption": "Story"
+      "StoryCaption": "Story",
+      "Unthemed": "Ohne Thema"
     },
     "PLACEHOLDERS": {
       "ColorPicker": "Wählen Sie eine Farbe aus",

--- a/lang/en.json
+++ b/lang/en.json
@@ -337,7 +337,8 @@
       "SceneCaption": "Scene",
       "SceneTagsLabel": "Scene Tags & Statuses",
       "SelectedHint": "Selected by the Narrator",
-      "StoryCaption": "Story"
+      "StoryCaption": "Story",
+      "Unthemed": "Unthemed"
     },
     "PLACEHOLDERS": {
       "ColorPicker": "Select a color",

--- a/lang/es.json
+++ b/lang/es.json
@@ -337,7 +337,8 @@
       "SceneCaption": "Escena",
       "SceneTagsLabel": "Etiquetas y estados de la escena",
       "SelectedHint": "Seleccionado por el Narrador",
-      "StoryCaption": "Historia"
+      "StoryCaption": "Historia",
+      "Unthemed": "Sin tema"
     },
     "PLACEHOLDERS": {
       "ColorPicker": "Selecciona un color",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -337,7 +337,8 @@
       "SceneCaption": "Scène",
       "SceneTagsLabel": "Tags et statuts de la scène",
       "SelectedHint": "Sélectionné par le Narrateur",
-      "StoryCaption": "Histoire"
+      "StoryCaption": "Histoire",
+      "Unthemed": "Sans thème"
     },
     "PLACEHOLDERS": {
       "ColorPicker": "Sélectionnez une couleur",

--- a/module/apps/scene-tags-overlay.mjs
+++ b/module/apps/scene-tags-overlay.mjs
@@ -97,37 +97,40 @@ export class MistSceneTagsOverlay extends HandlebarsApplicationMixin(Application
             selected: entry.selected === true
         })).filter(t => t.name?.trim());
 
-        const storyTags = MistSceneTagsOverlay.showStoryTags ? await this.#storyTags(sd) : [];
+        const storyTagGroups = MistSceneTagsOverlay.showStoryTags ? await this.#storyTagGroups(sd) : [];
 
         return {
             sceneTags,
-            storyTags,
+            storyTagGroups,
             hasSceneTags: sceneTags.length > 0,
-            hasStoryTags: storyTags.length > 0,
-            isEmpty: sceneTags.length === 0 && storyTags.length === 0
+            hasStoryTags: storyTagGroups.length > 0,
+            isEmpty: sceneTags.length === 0 && storyTagGroups.length === 0
         };
     }
 
     /**
-     * Power and weakness tags of the scene's story themes, flattened into one
-     * list. Uses the same filter as the Scene App's Story Themes tab: named,
-     * non-planned tags only.
+     * Power and weakness tags of the scene's story themes, grouped by their
+     * owning theme. Uses the same filter as the Scene App's Story Themes tab:
+     * named, non-planned tags only.
      * @param {Item|null} sd  the scene-data item
-     * @returns {Promise<Array<{name: string, weakness: boolean, theme: string}>>}
+     * @returns {Promise<Array<{uuid: string, name: string, tags: Array<{name: string, weakness: boolean, theme: string}>}>>}
      */
-    async #storyTags(sd) {
+    async #storyTagGroups(sd) {
         const uuids = sd?.system?.storyThemeIds ?? [];
-        const out = [];
+        const groups = [];
         for (const uuid of uuids) {
             const theme = await fromUuid(uuid).catch(() => null);
             if (theme?.type !== "themebook") continue;
+            const name = theme.name?.trim() || game.i18n.localize("MIST_ENGINE.OVERLAY.Unthemed");
+            const tags = [];
             const pick = (list, weakness) => (list ?? [])
                 .filter(t => t.name?.trim() && !t.planned)
-                .forEach(t => out.push({ name: t.name, weakness, theme: theme.name }));
+                .forEach(t => tags.push({ name: t.name, weakness, theme: name }));
             pick(theme.system.powertags, false);
             pick(theme.system.weaknesstags, true);
+            if (tags.length) groups.push({ uuid, name, tags });
         }
-        return out;
+        return groups;
     }
 
     /**

--- a/src/scss/components/_scene_tags_overlay.scss
+++ b/src/scss/components/_scene_tags_overlay.scss
@@ -79,15 +79,15 @@
 .litm-sto-theme-groups {
     display: flex;
     flex: 1 1 auto;
-    flex-wrap: wrap;
+    flex-direction: column;
     justify-content: center;
-    gap: 6px 12px;
+    gap: 6px;
     min-width: 0;
 }
 
 .litm-sto-theme-group {
     display: flex;
-    flex: 0 1 auto;
+    width: 100%;
     flex-wrap: wrap;
     align-items: baseline;
     justify-content: center;

--- a/src/scss/components/_scene_tags_overlay.scss
+++ b/src/scss/components/_scene_tags_overlay.scss
@@ -76,6 +76,33 @@
     min-width: 0;
 }
 
+.litm-sto-theme-groups {
+    display: flex;
+    flex: 1 1 auto;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 6px 12px;
+    min-width: 0;
+}
+
+.litm-sto-theme-group {
+    display: flex;
+    flex: 0 1 auto;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: center;
+    gap: 4px 7px;
+    min-width: 0;
+}
+
+.litm-sto-theme-name {
+    color: rgba(239, 214, 147, 0.88);
+    font-family: var(--litm-font-heading);
+    font-size: 0.72rem;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+}
+
 // Pill styling mirrors .fts-input-name in _tags.scss so the bar reads as the
 // same component family as the Scene App and the character sheets.
 .litm-sto-tag {

--- a/templates/overlay/scene-tags-overlay.hbs
+++ b/templates/overlay/scene-tags-overlay.hbs
@@ -21,10 +21,17 @@
         {{#if hasStoryTags}}
         <div class="litm-sto-row litm-sto-story">
             <span class="litm-sto-caption">{{localize 'MIST_ENGINE.OVERLAY.StoryCaption'}}</span>
-            <div class="litm-sto-tags">
-                {{#each storyTags}}
-                <span class="litm-sto-tag {{#if this.weakness}}weakness{{else}}tag{{/if}}"
-                    title="{{this.theme}}">{{this.name}}</span>
+            <div class="litm-sto-theme-groups">
+                {{#each storyTagGroups}}
+                <div class="litm-sto-theme-group" data-theme-uuid="{{this.uuid}}">
+                    <span class="litm-sto-theme-name">{{this.name}}</span>
+                    <div class="litm-sto-tags">
+                        {{#each this.tags}}
+                        <span class="litm-sto-tag {{#if this.weakness}}weakness{{else}}tag{{/if}}"
+                            title="{{this.theme}}">{{this.name}}</span>
+                        {{/each}}
+                    </div>
+                </div>
                 {{/each}}
             </div>
         </div>


### PR DESCRIPTION
I created my own module with this feature in it, and I decided to submit it so it could be in the official system. It simply adds some logic and css to organize the scene tags overlay by story theme, making it much easier to read at a glance if there are multiple story themes.

<img width="872" height="538" alt="image" src="https://github.com/user-attachments/assets/b45442eb-28a2-4fe7-a855-8ce8f52b2a35" />
